### PR TITLE
Fix some typos and links

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,7 +10,6 @@
     - [Install Epinio cli](user/installation/install_epinio_cli.md)
     - [Install Epinio with custom DNS](user/installation/install_epinio_customDNS.md)
     - [Install Epinio with "magic" DNS](user/installation/install_epinio_magicDNS.md)
-    - [Install Epinio with "magic" DNS](user/installation/install_epinio_magicDNS.md)
     - [Install Epinio on AKS (Azure)](user/installation/install_epinio_on_aks.md)
     - [Install Epinio on EKS (Amazon)](user/installation/install_epinio_on_eks.md)
     - [Install Epinio on GKE (Google)](user/installation/install_epinio_on_gke.md)

--- a/src/developer/howtos/development.md
+++ b/src/developer/howtos/development.md
@@ -110,6 +110,7 @@ the server after installation is done. While during installation only a suitable
 the ingress, and that then has to properly resolve in the DNS.
 
 <a id='curtain'>
+
 #### Behind the curtains
 
 `make install` does quite a bit more than the plain

--- a/src/user/howtos/gitjob_push.md
+++ b/src/user/howtos/gitjob_push.md
@@ -8,7 +8,7 @@ NOTE: We will improve this experience in the future!
 
 ### Install GitJob
 
-If you don't have Rancher (or standalone Fleet) installed, we need to install the GitJob operator by following the isntructions found at https://github.com/rancher/gitjob#running.
+If you don't have Rancher (or standalone Fleet) installed, we need to install the GitJob operator by following the instructions found at https://github.com/rancher/gitjob#running.
 
 
 Then we need to setup the Service Account to run our Jobs with (since we don't need to do anything directly with the kube api, we don't need to add any role bindings to it):


### PR DESCRIPTION
This PR fixes the following things:
* double link in the summary (install_epinio_magicDNS.md)
* Subtitle **Behind the curtains** not interpreted
* one typo in **gitjob_push**