### PR TITLE
Add Epinio installation on Minikube

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Install Epinio on k3d (local)](installation/install_epinio_on_k3d.md)
   - [Install Epinio on k3s (local)](installation/install_epinio_on_k3s.md)
   - [Install Epinio on Rancher Desktop (local)](installation/install_epinio_on_rancher_desktop.md)
+  - [Install Epinio on Minikube (local)](installation/install_epinio_on_minikube.md)
   - [Install Wordpress on Epinio](installation/install_wordpress_application.md)
 
 - [Uninstall Epinio](installation/uninstall_epinio.md)

--- a/src/installation/install_epinio_on_minikube.md
+++ b/src/installation/install_epinio_on_minikube.md
@@ -1,0 +1,50 @@
+# Creating a Minikube Kubernetes Cluster
+
+## Get Minikube Kubernetes Cluster
+
+### Install Minikube
+
+Follow the [instructions](https://minikube.sigs.k8s.io/docs/start/) to install Minikube on your system.
+
+### Create a Minikube kubernetes cluster
+
+Epinio installation was tested on Minikube with the following drivers: docker, kvm, virtualbox.
+
+Specify the driver you want to use with the `--driver` option.
+
+```bash
+$ minikube start --driver=docker
+```
+
+Once the cluster is ready, you need to install the metallb addon:
+
+```bash
+$ minikube addons enable metallb
+```
+
+Then, you have to configure metallb by giving it an IP address range.</br>
+For instance check your minikube IP with `minikube ip` and choose how many IP addresses you need.
+
+```bash
+$ minikube ip
+192.168.49.2
+```
+
+As an example, we choose the range `192.168.49.100-192.168.49.120`.</br>
+Configure the addon with those values.
+
+```bash
+$ minikube addons configure metallb
+-- Enter Load Balancer Start IP: 192.168.49.100
+-- Enter Load Balancer End IP: 192.168.49.120
+     Using image metallb/speaker:v0.9.6
+     Using image metallb/controller:v0.9.6
+  metallb was successfully configured
+```
+
+Now you can install Epinio on the Cluster.
+
+
+### Install Epinio on the Cluster
+
+Follow [Installation using a MagicDNS Service](./install_epinio_magicDNS.md) to install Epinio in your test environment.

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -32,6 +32,8 @@ Beside advanced installation options, there are two ways of installing Epinio:
 ### Installation on Specific Kubernetes Offerings
 
 - [Install on K3d](install_epinio_on_k3d.md) - Install K3d and then install Epinio
+- [Install on Minikube](install_epinio_on_minikube.md) - Install Minikube and then install Epinio
+- [Install on K3s](install_epinio_on_k3s.md) - Install Epinio in k3s clusters
 - [Install on EKS](install_epinio_on_eks.md) - Install Epinio in Amazon EKS clusters
 - [Install on AKS](install_epinio_on_aks.md) - Install Epinio in Azure AKS clusters
 - [Install on GKE](install_epinio_on_gke.md) - Install Epinio in Google GKE clusters


### PR DESCRIPTION
This PR adds documentation for installing Epinio on Minikube with different drivers.
I tested the deployment of the sample-app on the following drivers:
- kvm :heavy_check_mark: 
- docker :heavy_check_mark: 
- virtualbox :heavy_check_mark: 