### PR TITLE
Fix wordpress app example

### DIFF
--- a/src/installation/install_wordpress_application.md
+++ b/src/installation/install_wordpress_application.md
@@ -49,7 +49,7 @@ EOF
 ## Deploy
 
 ```
-epinio push wordpress
+epinio push -n wordpress wordpress
 ```
 
 ## Additional steps


### PR DESCRIPTION
Since v0.1.3 the application name must be provided explicitly.