### PR TITLE
Anonymize IPs in Google analytics

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,4 @@ edit-url-template = "https://github.com/epinio/docs/edit/main/{path}"
 site-url = "/"
 cname = "docs.epinio.io"
 google-analytics = "UA-56382716-12"
+anonymize-ip = true


### PR DESCRIPTION
This sets `anonymizeIp` to true when calling the Google analytics JavaScript.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>