### PR TITLE
Make navigation menu collapsible/expandable

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,4 +15,4 @@ cname = "docs.epinio.io"
 
 [output.html.fold]
 enable = true
-level = 0
+level = 1

--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,7 @@ edit-url-template = "https://github.com/epinio/docs/edit/main/{path}"
 site-url = "/"
 cname = "docs.epinio.io"
 google-analytics = "UA-56382716-12"
+
+[output.html.fold]
+enable = true
+level = 0


### PR DESCRIPTION
The current change will have all menu levels collapsed as the default behavior. What's the preferred default behavior? @agracey @jimmykarily?