### PR TITLE
Removed the epinio install reference

### DIFF
--- a/src/explanations/configuration.md
+++ b/src/explanations/configuration.md
@@ -34,13 +34,13 @@ The namespace can be changed by running `epinio target` with the
 name of the desired namespace as its single argument.
 
 User name and password are used by the client to authenticate itself
-when talking to Epinio's API server. The `epinio install` command
+when talking to Epinio's API server. The `epinio config update` command
 saves the initial information to the configuration.
 
 The installation uses a the wildcard domain `omg.howdoi.website` and the
 `epinio-ca` issuer by default.
 
-`epinio install` saves the associated CA
+`epinio config update` saves the associated CA
 certificate to the configuration so that future invocations of the
 client are able to verify the actual certificate when talking to
 Epinio's API server.

--- a/src/howtos/certificate_issuers.md
+++ b/src/howtos/certificate_issuers.md
@@ -10,11 +10,8 @@ The issuer will be used for both, the Epinio API endpoint and workloads (i.e. pu
 
 ## Choosing a Different Issuer
 
-When installing Epinio, one can choose between those issuers by using the `--tls-issuer` argument:
+When installing Epinio, one can choose between those issuers by using the `tlsIssuer` variable:
 
-```
-epinio install --tls-issuer=letsencrypt-production
-```
 
 ## Using a custom issuer
 
@@ -22,22 +19,8 @@ It's possible to create a cert-manager cluster issuer in the cluster, before ins
 
 However, this is only possible if the cert-manager CRD is present in the cluster.
 
-We can use a split install, to install cert-manager first, then create the cluster issuer and finally install Epinio.
+Install cert-manager first, then create the cluster issuer and finally install Epinio with the correct `tlsIssuer`.
 
-
-### Split Install
-
-Install cert-manager first:
-
-```
-epinio install-cert-manager
-```
-
-Then after creating the cluster issuer, install Epinio:
-
-```
-epinio install --skip-cert-manager
-```
 
 ### Cluster Issuer for ACME DNS Challenge
 
@@ -68,10 +51,13 @@ spec:
 
 Note: This uses the Letsencrypt staging endpoint for testing. More information in the [cert-manager ACME docs](https://cert-manager.io/docs/configuration/acme/dns01/).
 
-You can then install Epinio, without cert-manager, pointing to the new cluster issuer:
+You can then install Epinio, with the `skipCertManager` variable, and the `tlsIssuer` pointing to the new cluster issuer:
 
 ```
-epinio install --skip-cert-manager --tls-issuer=dns-staging
+helm install \
+  --set skipCertManager=true \
+  --set tlsIssuer=dns-staging \
+  epinio-installer epinio/epinio-installer
 ```
 
 ### Cluster Issuer for Existing Private CA
@@ -114,10 +100,14 @@ spec:
 
 #### Install Epinio
 
-Use the `--tls-issuer` argument to choose your cluster issuer:
+Use the `tlsIssuer` variable to choose your cluster issuer:
+
 
 ```
-epinio install --skip-cert-manager --tls-issuer=private-ca
+helm install \
+  --set skipCertManager=true \
+  --set tlsIssuer=private-ca \
+  epinio-installer epinio/epinio-installer
 ```
 
 # Use TLS When Pulling From Internal Registry
@@ -127,6 +117,12 @@ If you are using a certificate issuer whose CA is trusted by the Kubernetes node
 
 ```
 epinio install --tls-issuer=letsencrypt-production --use-internal-registry-node-port=false
+```
+
+```
+helm install \
+  --set tlsIssuer=letsencrypt-production \
+  epinio-installer epinio/epinio-installer
 ```
 
 Without the node port, pushing images to the registry uses the "epinio-registry" ingress, which is handled by Traefik.
@@ -139,7 +135,7 @@ An *ingress* resource can then use that secret to set up TLS.
 
 Example:
 
-1. `epinio install` creates a certificate resource in epinio namespace
+1. The Epinio installation creates a certificate resource in epinio namespace
 
 ```
 apiVersion: cert-manager.io/v1alpha2

--- a/src/howtos/gitjob_push.md
+++ b/src/howtos/gitjob_push.md
@@ -28,7 +28,7 @@ So the GitJob can authenticate and push correctly, we can upload our Epinio conf
 kubectl create secret generic epinio-creds --from-file=$HOME/.config/epinio/config.yaml
 ```
 
-This will create a secret containing the config.yaml that was created locally when you do `epinio install` or `epinio config update`
+This will create a secret containing the config.yaml that was created locally when you do `epinio config update`
 
 ### Setup Sample Project
 

--- a/src/howtos/setup-external-registry.md
+++ b/src/howtos/setup-external-registry.md
@@ -1,18 +1,16 @@
 ## How to setup external Epinio registry
 
-Epinio allows the use of an external registry for the storage of application images.  This can be achieved by setting the following arguments during `epinio install`:
+Epinio allows the use of an external registry for the storage of application images.  This can be achieved by setting the following variables during the `helm install`:
 
 ```
-epinio install \
-  --external-registry-namespace=$REGISTRY_NAMESPACE \
-  --external-registry-password=$REGISTRY_PASSWORD \
-  --external-registry-url=$REGISTRY_URL \
-  --external-registry-username=$REGISTRY_USER \
-  ...
+helm install \
+  --set externalRegistryNamespace=$REGISTRY_NAMESPACE \
+  --set externalRegistryURL=$REGISTRY_URL \
+  --set externalRegistryUsername=$REGISTRY_USER \
+  --set externalRegistryPassword=$REGISTRY_PASSWORD \
+  epinio-installer epinio/epinio-installer
 ```
-
-(See also `epinio install --help`)
 
 Using [dockerhub](https://hub.docker.com/) as an example, the user would have to set the value of `$REGISTRY_URL` to `registry.hub.docker.com`, `$REGISTRY_USER` and `$REGISTRY_PASSWORD` would be set to the dockerhub credentials, and `$REGISTRY_NAMESPACE` would be either an organization or the username.
 
-When the above arguments are set, Epinio doesn't deploy a registry on the cluster. Also the `--force-kube-internal-registry-tls` flag should not be used because it would have no effect.
+When the above arguments are set, Epinio doesn't deploy a registry on the cluster. Also the `forceKubeInternalRegistryTLS` variable should not be set because it would have no effect.

--- a/src/installation/install_epinio_customDNS.md
+++ b/src/installation/install_epinio_customDNS.md
@@ -10,15 +10,6 @@ For test and production environments. The installation will be done in three ste
 
 If not done already, refer to [Install the Epinio CLI](./install_epinio_cli.md).
 
-## Install Ingress In Cluster
-
-First install ingress and wait for the `loadbalancer-ip` to be provisioned for the `traefik` public IP. Then map the `loadbalancer-ip` to your `Domain Name` e.g. `test.example.com` and wait for it to be mapped.
-
-```bash
-epinio install-ingress
-```
-
-The command prints the `loadbalancer-ip` ("EXTERNAL-IP") needed. Note however that it can also print a loadbalanced FQDN instead, which may resolve to multiple IPs.
 
 ## Configure your custom DOMAIN
 
@@ -39,18 +30,6 @@ and Ingress will route the traffic accordingly.
 
 Find [DNS Configuration Examples](#dns-configuration-examples) below.
 
-## Install Epinio In Cluster
-With DNS now available the second step actually installs the cluster:
-
-```bash
-epinio install --system-domain test.example.com --tls-issuer=letsencrypt-production --use-internal-registry-node-port=false
-```
-
-***
-
-###### Note: The issuer `letsencrypt-production` will work only, if your custom domain, e.g. "test.example.com", is reachable from the internet. For test, or internal environments, where your custom domain isn't reachable from the internet, you need to choose a different issuer. E.g. if you would use the custom domain "test.internal.com", `epinio install --system-domain test.internal.com` will default to the `epinio-ca` issuer.
-
-***
 
 ## DNS Configuration Examples
 

--- a/src/installation/install_epinio_magicDNS.md
+++ b/src/installation/install_epinio_magicDNS.md
@@ -1,17 +1,7 @@
 # Install Epinio using a Magic DNS Service
 
-This is about just running `epinio install`. It should work on nearly any kubernetes distribution and provides you with a test environment.
-You will automatically get a magic wildcard domain like "10.0.0.1.omg.howdoi.website" which points to the public IP of Traefik.
+In order to use a magic domain that will resolve to a local/private IP you can use the [auto installation method](./install_epinio_auto.md) and set the EPINIO_SYSTEM_DOMAIN variable to `<IP>.omg.howdoi.website`.
 
-## Install the Epinio CLI
-
-If not done already, refer to [Install the Epinio CLI](./install_epinio_cli.md).
-
-### Install Epinio on the Cluster
-
-```bash
-epinio install
-```
 
 ### Troubleshooting
 

--- a/src/installation/install_epinio_on_k3d.md
+++ b/src/installation/install_epinio_on_k3d.md
@@ -34,12 +34,6 @@ k3d-epinio-server-0   Ready    control-plane,master   38s   v1.20.0+k3s2
 
 Follow [Installation using a MagicDNS Service](./install_epinio_magicDNS.md) to install Epinio in your test environment.
 
-If k3d is inside a VM, in addition to the special k3d setup, explained above, use this system domain instead:
-
-```bash
-epinio install --system-domain=<YOUR-IP>.omg.howdoi.website
-```
-
 `<YOUR-IP>` can be found by running
 
 ```bash

--- a/src/installation/install_epinio_on_k3s.md
+++ b/src/installation/install_epinio_on_k3s.md
@@ -6,7 +6,7 @@ Note: this documentation was tested with Epinio v0.1.3 and k3s v1.21.5+k3s2 on o
 
 ### Install K3s
 
-Follow the [instructions](https://k3s.io/) to install k3d on your system.
+Follow the [instructions](https://k3s.io/) to install k3s on your system.
 
 ### Install Epinio on the Cluster
 

--- a/src/installation/install_epinio_on_rancher_desktop.md
+++ b/src/installation/install_epinio_on_rancher_desktop.md
@@ -19,19 +19,7 @@ Make sure Rancher Desktop is running.
 Rancher Desktop can report Kubernetes as running while some pods are actually not yet ready.
 Manual verification is possible by executing the command `kubectl get pods -A` in a terminal and checking that all pods report either `Running` or `Completed` as their status.
 
-### Windows
-
-1. Start a terminal (e.g. type `cmd` in the search field) and change to the directory where `epinio-windows-amd64` is located, e.g. `cd Downloads`
-
-2. Run `epinio-windows-amd64 install`
-
-3. Copy the binary to a directory of your choice and add it to the `PATH` variable as described by [Kevin Berg's article](https://medium.com/@kevinmarkvi/how-to-add-executables-to-your-path-in-windows-5ffa4ce61a53). This allows execution of Epinio directly from any terminal.
-
-### Mac
-
-1. Start a terminal and change to the directory where `epinio-darwin-amd64` is located, e.g. `cd Downloads`
-
-2. Run `epinio-darwin-amd64 install`
+Follow [Installation using a Custom Domain](./install_epinio_customDNS.md) for test and production environments.
 
 ### Linux
 


### PR DESCRIPTION
Removed all the `epinio install` references, and changed when appropriate with links or the `helm install` equivalent.