### PR TITLE
Removal of lingering references to the old installer

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -70,9 +70,6 @@
         - [epinio_config_update](references/cli/epinio_config_update.md)
 
       - [epinio_info](references/cli/epinio_info.md)
-      - [epinio_install-cert-manager](references/cli/epinio_install-cert-manager.md)
-      - [epinio_install-ingress](references/cli/epinio_install-ingress.md)
-      - [epinio_install](references/cli/epinio_install.md)
       - [epinio_namespace](references/cli/epinio_namespace.md)
 
         - [epinio_namespace_create](references/cli/epinio_namespace_create.md)
@@ -92,7 +89,6 @@
         - [epinio_service_unbind](references/cli/epinio_service_unbind.md)
 
       - [epinio_target](references/cli/epinio_target.md)
-      - [epinio_uninstall](references/cli/epinio_uninstall.md)
       - [epinio_version](references/cli/epinio_version.md)
 
   - [Supported Applications](references/supported-apps.md)

--- a/src/explanations/detailed-push-process.md
+++ b/src/explanations/detailed-push-process.md
@@ -61,7 +61,7 @@ You can get the route of your application with `epinio apps list` or `epinio app
 
 ## Additional Things
 
-During installation, if you specified a system domain using the `--system-domain` parameter, then your application routes will be subdomains of that domain.
+During installation, if you specified a system domain using the `--set domain=...` option of the chart, then your application routes will be subdomains of that domain.
 If you didn't specify a system domain then Epinio uses a "magic DNS" service running on the `omg.howdoi.website` which is similar to [nip.io](https://nip.io/), and [xip.io](http://xip.io/).
 These services resolve all subdomains of the root domain to the subdomain's IP address. E.g. `1.2.3.4.omg.howdoi.website` simply resolves to `1.2.3.4`. They are useful when you don't have a real domain but you still need a wildcard domain to create subdomains for. Depending on your setup, the IP address of the cluster which Epinio discovers automatically may not be accessible by your browser and thus you may need to set the system domain when installing to use another IP. This is the case for example when you run a Kubernetes cluster with docker (e.g. [k3d](https://k3d.io/) or [kind](https://github.com/kubernetes-sigs/kind)) inside a VM (for example when using docker on Mac). Then the IP address which Epinio detects is the IP address of the docker container but that is not accessible from your host. You will need to bind the container's ports `80` and `443` to the VMs ports `80` and `443` and then use the VMs IP address instead.
 

--- a/src/explanations/security.md
+++ b/src/explanations/security.md
@@ -2,7 +2,7 @@
 
 Epinio secures access to its API with TLS and basic authentication.
 
-The installation process automatically creates and saves the necessary credentials
+Use the `epinio config update` command after installation to extract and save the necessary credentials
 (user, password) and certificates. The information is stored in Epinio's configuration,
 for pickup by other Epinio commands.
 
@@ -11,7 +11,7 @@ underlying cluster, and self-signed, and its CA certificate is stored in the
 configuration to allow verification.
 
 For a production-oriented deployment on the other hand, with a proper
-`--system-domain` specified, the certificate is obtained from
+domain specified (`--set domain=...` when installing the chart), the certificate is obtained from
 [Let's Encrypt](https://letsencrypt.org/) instead. Nothing is stored in the
 configuration in that case, as Let's Encrypt is a known CA.
 


### PR DESCRIPTION
fix #34 

fix: some old references to the old (cli) installer.
removed: old behaviour not present in current helm-based system.
