### PR TITLE
Add new install method

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -6,8 +6,7 @@
 
 - [Installation](installation/installation.md)
   - [System Requirements](installation/system_requirements.md)
-  - [Method 1: Install Epinio and automatically install dependencies](installation/install_epinio_auto.md)
-  - [Method 2: Install Epinio and manually install dependencies](installation/install_epinio_manual.md)
+  - [Install Epinio](installation/installation.md)
   - [Install Epinio on Rancher](installation/install_epinio_on_rancher.md)
   - [Install Epinio cli](installation/install_epinio_cli.md)
   - [Install Epinio with custom DNS](installation/install_epinio_customDNS.md)

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -62,7 +62,7 @@ the helm value "kubed.enabled" to "false".
 Epinio is using an S3 compatible storage to store the application source code.
 This chart will install [Minio](https://min.io/) when `.Values.minio.enabled` is
 true (default). Any S3 compatible solution can be used instead by setting this
-value to `false` and using [the values under `s3`](https://github.com/epinio/helm-charts/blob/7ce84a4b391105551ba52f9ab8ea7213b5358977/chart/epinio/values.yaml#L49)
+value to `false` and using [the values under `s3`](https://github.com/epinio/helm-charts/blob/main/chart/epinio/values.yaml#L44)
 to point to the desired S3 server. 
 
 ### Container Registry
@@ -73,7 +73,7 @@ on the cluster when `.Values.containerregistry.enabled` is `true` (default).
 
 Any container registry that supports basic auth authentication can be used (e.g. gcr, dockerhub etc)
 instead by setting this value to `false` and using
-[the values under `registry`](https://github.com/epinio/helm-charts/blob/7ce84a4b391105551ba52f9ab8ea7213b5358977/chart/epinio/values.yaml#L57-L76)
+[the values under `registry`](https://github.com/epinio/helm-charts/blob/main/chart/epinio/values.yaml#L104-L107)
 to point to the desired container registry.
 
 ### Install Epinio

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -1,9 +1,10 @@
 # Installation of Epinio
 
 ## Introduction
-Epinio is installed from a single Helm chart and, by default, it also installs [`Kubed`](#kubed) and [`MinIO`](#s3-storage) in your Kubernetes cluster.
+Epinio is installed from a single Helm chart and, by default, it also installs [`Kubed`](#kubed), [`MinIO`](#s3-storage) 
+and a [container registry](#container-registry) in your Kubernetes cluster.
 
-You can disable the installation of `Kubed` and `MinIO` by changing the settings as described in the respective sections.
+You can disable the installation of `Kubed`, `MinIO` and the `container registry` by changing the settings as described in the respective sections.
 
 
 ## Prerequisites

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -1,7 +1,7 @@
 # Installation of Epinio
 
 ## Introduction
-Epinio is installed from a single Helm chart, which checks for the [dependencies]() required 
+Epinio is installed from a single Helm chart, which checks for the dependencies required 
 and install them if they're not present in your Kubernetes cluster.
 
 ## Prerequisites

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -1,8 +1,10 @@
 # Installation of Epinio
 
 ## Introduction
-Epinio is installed from a single Helm chart, which checks for the dependencies required 
-and install them if they're not present in your Kubernetes cluster.
+Epinio is installed from a single Helm chart and, by default, it also installs [`Kubed`](#kubed) and [`MinIO`](#s3-storage) in your Kubernetes cluster.
+
+You can disable the installation of `Kubed` and `MinIO` by changing the settings as described in the respective sections.
+
 
 ## Prerequisites
 

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -51,6 +51,9 @@ $ helm install cert-manager --namespace cert-manager jetstack/cert-manager \
 		--set extraArgs[0]=--enable-certificate-owner-ref=true
 ```
 
+> **WARNING**: if cert-manager isn't installed in the namespace `cert-manager`,
+> you have to set `.Values.certManagerNamespace` accordingly, otherwise Epinio installation will fail.
+
 ### Kubed
 
 Kubed is installed as a subchart when `.Values.kubed.enabled` is true (default).

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -101,4 +101,4 @@ To help you, see the following HowTos for various well-known Kubernetes clusters
 - [Install on Rancher Desktop](install_epinio_on_rancher_desktop.md) - Install Epinio on Rancher Desktop
 - [Install on Minikube](install_epinio_on_minikube.md) - Install Epinio on Minikube cluster
 
-> *NOTE*: The Public Cloud howto lists the three major Cloud providers.
+> *NOTE*: The Public Cloud howto lists the three major Cloud providers but Epinio can run on any Kubernetes cluster.


### PR DESCRIPTION
the new installation method with a single Helm chart has been added.

The previous "two methods" have been removed from the Summary. However the pages are kept for the time being, in case someone has a reference to it. They will/should be removed in the future.