### PR TITLE
Updated links for new structure

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [Setup external container registry](howtos/setup_external_registry.md)
   - [Port Forwarding](howtos/port_forwarding.md)
   - [Custom Routes](howtos/custom_routes.md)
+  - [Install Epinio on Rancher](howtos/install_epinio_on_rancher.md)
   - [Install Epinio on RKE2 (Rancher)](howtos/install_epinio_on_rke.md)
   - [Install Epinio on K3s (local)](howtos/install_epinio_on_k3s.md)
   - [Install Epinio on Rancher Desktop (local)](howtos/install_epinio_on_rancher_desktop.md)

--- a/src/installation/install_epinio_cli.md
+++ b/src/installation/install_epinio_cli.md
@@ -2,12 +2,12 @@
 
 ## Before you begin
 
-If not done already, refer to [System Requirements](./system_requirements.md).
+If not done already, refer to [System Requirements](/references/system_requirements.md).
 
 ## Install Dependencies
 
-- `kubectl`: Follow instructions here: https://kubernetes.io/docs/tasks/tools/#kubectl
-- `helm`: Follow instructions here: https://helm.sh/docs/intro/install/
+- `kubectl`: Follow instructions [here](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- `helm`: Follow instructions [here](https://helm.sh/docs/intro/install/)
 
 ## Install Epinio CLI
 

--- a/src/installation/install_epinio_customDNS.md
+++ b/src/installation/install_epinio_customDNS.md
@@ -12,9 +12,7 @@ If not done already, refer to [Install the Epinio CLI](./install_epinio_cli.md).
 
 ## Install Epinio on your cluster
 
-Use `helm` to install Epinio by following either:
-- [Method 1](./install_epinio_auto.md), recommended for most cases
-- [Method 2](./install_epinio_manual.md), useful for advanced configuration or if you already have some components in your environment
+Epinio is installed from a single Helm chart. You can follow the steps described in [Install Epinio](installation.md) page.
 
 ## Configure your Custom Domain
 

--- a/src/installation/install_epinio_magicDNS.md
+++ b/src/installation/install_epinio_magicDNS.md
@@ -4,7 +4,7 @@ If not done already, refer to [Install the Epinio CLI](./install_epinio_cli.md).
 
 # Install Epinio using a Magic DNS Service
 
-In order to use a magic domain that will resolve to a local/private IP you can use the [auto installation method (aka. Method 1)](./install_epinio_auto.md) and set the **EPINIO_SYSTEM_DOMAIN** variable to `<IP>.omg.howdoi.website`.
+Once you installed Epinio, as described in [Install Epinio](installation.md) page, you can use a magic domain that will resolve to a local/private IP and set the **EPINIO_SYSTEM_DOMAIN** variable to `<IP>.omg.howdoi.website`.
 
 
 ## Troubleshooting

--- a/src/installation/installation.md
+++ b/src/installation/installation.md
@@ -9,7 +9,7 @@ You can disable the installation of `Kubed`, `MinIO` and the `container registry
 
 ## Prerequisites
 
-See [system requirements](system_requirements.md) for a detailed list of external components your
+See [system requirements](/references/system_requirements.md) for a detailed list of external components your
 Kubernetes cluster needs to have before you install Epinio.
 
 > **IMPORTANT:** Some of the namespaces of the components are hardcoded in the Epinio
@@ -93,18 +93,20 @@ The only value that is mandatory is the `.Values.global.domain` which
 should be a wildcard domain, pointing to the IP address of your running
 Ingress controller.
 
+> *NOTE*: If you're deploying Epinio in a "localhost" environment, you can use a "[magic domain name](install_epinio_magicDNS.md)". 
+
 ## Installation on Specific Kubernetes Offerings
 
 Installing Epinio is a standard process as explained above, however you might need to configure it for a specific Kubernetes cluster.
 
 To help you, see the following HowTos for various well-known Kubernetes clusters:
 
-- [Install on Rancher](install_epinio_on_rancher.md) - Install Epinio on Rancher
-- [Install on Public Cloud](install_epinio_on_public_cloud.md) - Install Epinio on Public Cloud cluster
-- [Install on RKE2](install_epinio_on_rke.md) - Install Epinio on Rancher RKE2 cluster
-- [Install on K3d](install_epinio_on_k3d.md) - Install Epinio on K3d cluster
-- [Install on K3s](install_epinio_on_k3s.md) - Install Epinio on K3s cluster
-- [Install on Rancher Desktop](install_epinio_on_rancher_desktop.md) - Install Epinio on Rancher Desktop
-- [Install on Minikube](install_epinio_on_minikube.md) - Install Epinio on Minikube cluster
+- [Install on Rancher](/howtos/install_epinio_on_rancher.md) - Install Epinio on Rancher
+- [Install on Public Cloud](/howtos/install_epinio_on_public_cloud.md) - Install Epinio on Public Cloud cluster
+- [Install on RKE2](/howtos/install_epinio_on_rke.md) - Install Epinio on Rancher RKE2 cluster
+- [Install on K3d](/howtos/install_epinio_on_k3d.md) - Install Epinio on K3d cluster
+- [Install on K3s](/howtos/install_epinio_on_k3s.md) - Install Epinio on K3s cluster
+- [Install on Rancher Desktop](/howtos/install_epinio_on_rancher_desktop.md) - Install Epinio on Rancher Desktop
+- [Install on Minikube](/howtos/install_epinio_on_minikube.md) - Install Epinio on Minikube cluster
 
 > *NOTE*: The Public Cloud howto lists the three major Cloud providers but Epinio can run on any Kubernetes cluster.


### PR DESCRIPTION
Fixes #64

The overall links in the Installation section have been updated to reflect the new Docs structure.

The references to the previous two methods have been also updated to mention the new single installation method