### PR TITLE
Automate downloard url using updatecli 

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,31 @@
+---
+name: "Updatecli: Dependency Management"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 * * * *'
+  repository_dispatch:
+    types: [epinio-release, epinio-ui-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Apply
+        uses: updatecli/updatecli-action@v1.23.0
+        with:
+          command: apply
+          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -6,8 +6,6 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 * * * *'
-  repository_dispatch:
-    types: [epinio-release, epinio-ui-release]
 
 permissions:
   contents: write

--- a/src/installation/install_epinio_cli.md
+++ b/src/installation/install_epinio_cli.md
@@ -16,7 +16,6 @@ brew install epinio
 ## From the Binary Releases
 
 Find the latest version at [Releases](https://github.com/epinio/epinio/releases).
-Run one of the commands below, and replace \<epinio-version\> with the version of your choice, e.g. "v0.6.0".
 
 ### Linux
 

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -1,0 +1,57 @@
+title: Bump Epinio version in installation documentation
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: epinio-bot
+      email: bot@epinio.io
+      owner: epinio
+      repository: docs
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+
+sources:
+  updatecli:
+    name: Get latest Epinio version
+    kind: githubRelease
+    spec:
+      owner: epinio
+      repository: epinio
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+
+targets:
+  download-url:
+    name: 'Update Epinio Installation URL'
+    kind: file
+    spec:
+      file: src/installation/install_epinio_cli.md
+      matchPattern: 'https://github.com/epinio/epinio/releases/download/(.*)/'
+      replacePattern: 'https://github.com/epinio/epinio/releases/download/{{ source "updatecli" }}/'
+    scmID: default
+
+  epinio-version:
+    name: 'Update Epinio Installation URL'
+    kind: file
+    spec:
+      file: src/installation/install_epinio_cli.md
+      matchPattern: 'Epinio Version: (.*)'
+      replacePattern: 'Epinio Version: {{ source "updatecli" }}'
+    scmID: default
+
+pullrequests:
+  default:
+    title: '[updatecli] Bump Epinio version used within installation documentation to {{ source "epinio" }}'
+    kind: github
+    scmID: default
+    targets:
+      - download-url
+      - epinio-version
+    spec:
+      automerge: true
+      mergemethod: squash
+      labels:
+        - chore
+


### PR DESCRIPTION
Fix #76 

While looking at the Epinio cli installation page, I noticed that the version was outdated and it seems to be a manual procedure to update it so I propose to automate the process 

Example of the updatecli manifest executed locally. Please not that I didn't update the url as I would like to test that updatecli can do it from Github Action 

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/installation.yaml"

SCM repository retrieved: 0


++++++++++++
+ PIPELINE +
++++++++++++



#####################################################
# BUMP EPINIO VERSION IN INSTALLATION DOCUMENTATION #
#####################################################


SOURCES
=======

updatecli
---------
Searching for version matching pattern "latest"
✔ Github Release version "v0.6.1" found matching pattern "latest"


CHANGELOG:
----------

Release published on the 2022-03-15 11:13:08 +0000 UTC at the url https://github.com/epinio/epinio/releases/tag/v0.6.1


# What's Changed

## 🚀 Features

- Add Restage Command to CLI (#1290)
- Add Namespace Parameter Server and Settings Command (#1293)

## 🧰 Maintenance

- Bump go.mod to 1.17, update modules (#1296)
- Moved AppLogs to APIClient (#1291)

# Usage

More info can be found in the [installation instructions](https://docs.epinio.io/installation/installation.html).



TARGETS
========

download-url
------------

**Dry Run enabled**

⚠ File content for "src/installation/install_epinio_cli.md", updated. 

--- src/installation/install_epinio_cli.md
+++ src/installation/install_epinio_cli.md
@@ -20,19 +20,19 @@
 ### Linux
 
 ```bash
-curl -o epinio -L https://github.com/epinio/epinio/releases/download/<epinio-version>/epinio-linux-x86_64
+curl -o epinio -L https://github.com/epinio/epinio/releases/download/v0.6.1/epinio-linux-x86_64
 ```
 
 ### MacOS
 
 ```bash
-curl -o epinio -L https://github.com/epinio/epinio/releases/download/<epinio-version>/epinio-darwin-x86_64
+curl -o epinio -L https://github.com/epinio/epinio/releases/download/v0.6.1/epinio-darwin-x86_64
 ```
 
 ### Windows
 
 ```bash
- curl -LO https://github.com/epinio/epinio/releases/download/<epinio-version>/epinio-windows-x86_64.zip
+ curl -LO https://github.com/epinio/epinio/releases/download/v0.6.1/epinio-windows-x86_64.zip
 ```
 
 Extract the zip archive and put the binary in a directory that is in your `PATH` environment variable. Instructions on how to add directories to the `PATH` vary depending on your version of Windows.


epinio-version
--------------

**Dry Run enabled**

⚠ File content for "src/installation/install_epinio_cli.md", updated. 

--- src/installation/install_epinio_cli.md
+++ src/installation/install_epinio_cli.md
@@ -55,6 +55,6 @@
 
 ```bash
 > epinio version
-Epinio Version: v0.6.0
+Epinio Version: v0.6.1
 Go Version: go1.17
 ```


=============================

REPORTS:


⚠ INSTALLATION.YAML:
	Sources:
		✔ [updatecli] Get latest Epinio version (kind: githubRelease)
	Target:
		⚠ [download-url] Update Epinio Installation URL (kind: file)
		⚠ [epinio-version] Update Epinio Installation URL (kind: file)



Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

```