### PR TITLE
Fix some doc issues

### DIFF
--- a/docs/howtos/create_custom_service.md
+++ b/docs/howtos/create_custom_service.md
@@ -22,8 +22,6 @@ $ kubectl get services.application.epinio.io -n epinio mysql-dev -o yaml > servi
 or you can find the definition of the catalog services [here](https://github.com/epinio/helm-charts/blob/3a12bac7aee5ac36c6d43416f2e83ac10090c62a/chart/epinio/templates/service-catalog.yaml
 ).
 
-https://github.com/epinio/helm-charts/blob/3a12bac7aee5ac36c6d43416f2e83ac10090c62a/chart/epinio/templates/service-catalog.yaml
-
 Change the fields to point to the desired helm chart and apply the yaml with a command like:
 
 ```

--- a/docs/howtos/install_epinio_on_public_cloud.md
+++ b/docs/howtos/install_epinio_on_public_cloud.md
@@ -20,6 +20,12 @@ Epinio can be installed on any Kubernetes distribution, including the Public Clo
 ### Create an AKS cluster
 
 If you do not have an existing cluster, follow the [quickstart](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) to create an AKS cluster.
+
+:::caution
+
+In AKS, Epinio must be installed with an external registry because due to a [change](https://github.com/epinio/epinio/issues/1373#issuecomment-1105231113) in Azure, we cannot use internal registry anymore.
+
+:::
 </details>
 
 <details>

--- a/docs/howtos/install_epinio_on_rancher_desktop.md
+++ b/docs/howtos/install_epinio_on_rancher_desktop.md
@@ -48,7 +48,7 @@ $ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/downloa
 # Wait for cert-manager to stabilize
 
 $ helm repo add epinio https://epinio.github.io/helm-charts
-$ helm install epinio -n epinio --create-namespace epinio/epinio --values epinio-values.yaml --set global.domain=127.0.0.1.sslip.io
+$ helm install epinio -n epinio --create-namespace epinio/epinio --set global.domain=127.0.0.1.sslip.io
 
 $ epinio settings update
 ```

--- a/docs/howtos/install_wordpress_application.md
+++ b/docs/howtos/install_wordpress_application.md
@@ -62,5 +62,5 @@ epinio push --name wordpress
 Wordpress needs a database to work. After visiting the route of your deployed
 application you will have to set the connection details to the database.
 
-You can install a MySQL database on your cluster or use an external one. One
-option is using a helm chart like [this one](https://bitnami.com/stack/mysql/helm)
+You can use the [Service](../references/services.md) feature to deploy your database with Epinio.
+Of course, deploying a database manually is still possible.

--- a/docs/installation/uninstall_epinio.md
+++ b/docs/installation/uninstall_epinio.md
@@ -6,7 +6,7 @@ title: ""
 ## Uninstall
 
 NOTE: The command below will delete all the components Epinio originally installed.
-**This includes all the deployed applications.**
+**This includes all the deployed applications in the default "workspace" namespace, resources deployed in your own namespace will survive.**
 
 If after installing Epinio, you deployed other things on the same cluster
 that depended on those Epinio deployed components (e.g. Kubed, Minio etc),

--- a/versioned_docs/version-0.7.1/howtos/create_custom_service.md
+++ b/versioned_docs/version-0.7.1/howtos/create_custom_service.md
@@ -22,8 +22,6 @@ $ kubectl get services.application.epinio.io -n epinio mysql-dev -o yaml > servi
 or you can find the definition of the catalog services [here](https://github.com/epinio/helm-charts/blob/3a12bac7aee5ac36c6d43416f2e83ac10090c62a/chart/epinio/templates/service-catalog.yaml
 ).
 
-https://github.com/epinio/helm-charts/blob/3a12bac7aee5ac36c6d43416f2e83ac10090c62a/chart/epinio/templates/service-catalog.yaml
-
 Change the fields to point to the desired helm chart and apply the yaml with a command like:
 
 ```

--- a/versioned_docs/version-0.7.1/howtos/install_epinio_on_public_cloud.md
+++ b/versioned_docs/version-0.7.1/howtos/install_epinio_on_public_cloud.md
@@ -20,6 +20,12 @@ Epinio can be installed on any Kubernetes distribution, including the Public Clo
 ### Create an AKS cluster
 
 If you do not have an existing cluster, follow the [quickstart](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) to create an AKS cluster.
+
+:::caution
+
+In AKS, Epinio must be installed with an external registry because due to a [change](https://github.com/epinio/epinio/issues/1373#issuecomment-1105231113) in Azure, we cannot use internal registry anymore.
+
+:::
 </details>
 
 <details>

--- a/versioned_docs/version-0.7.1/howtos/install_epinio_on_rancher_desktop.md
+++ b/versioned_docs/version-0.7.1/howtos/install_epinio_on_rancher_desktop.md
@@ -48,7 +48,7 @@ $ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/downloa
 # Wait for cert-manager to stabilize
 
 $ helm repo add epinio https://epinio.github.io/helm-charts
-$ helm install epinio -n epinio --create-namespace epinio/epinio --values epinio-values.yaml --set global.domain=127.0.0.1.sslip.io
+$ helm install epinio -n epinio --create-namespace epinio/epinio --set global.domain=127.0.0.1.sslip.io
 
 $ epinio settings update
 ```

--- a/versioned_docs/version-0.7.1/howtos/install_wordpress_application.md
+++ b/versioned_docs/version-0.7.1/howtos/install_wordpress_application.md
@@ -62,5 +62,5 @@ epinio push --name wordpress
 Wordpress needs a database to work. After visiting the route of your deployed
 application you will have to set the connection details to the database.
 
-You can install a MySQL database on your cluster or use an external one. One
-option is using a helm chart like [this one](https://bitnami.com/stack/mysql/helm)
+You can use the [Service](../references/services.md) feature to deploy your database with Epinio.
+Of course, deploying a database manually is still possible.

--- a/versioned_docs/version-0.7.1/installation/uninstall_epinio.md
+++ b/versioned_docs/version-0.7.1/installation/uninstall_epinio.md
@@ -6,7 +6,7 @@ title: ""
 ## Uninstall
 
 NOTE: The command below will delete all the components Epinio originally installed.
-**This includes all the deployed applications.**
+**This includes all the deployed applications in the default "workspace" namespace, resources deployed in your own namespace will survive.**
 
 If after installing Epinio, you deployed other things on the same cluster
 that depended on those Epinio deployed components (e.g. Kubed, Minio etc),


### PR DESCRIPTION
This PR tries to improve/fix 5 things in the doc:

1. Remove duplicate link for service page
2. Warn the user about deployment in the default workspace in case of uninstallation, fix #107 
3. Advertise service feature in the wordpress example
4. Remove `--values epinio-values.yaml` in Epinio installation on Rancher Desktop
5. If you want to use Epinio on AKS, you must use external registry, fix #104 