### PR TITLE
Automate docusaurus version update

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Docusaurus
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+
       - name: Apply
         uses: updatecli/updatecli-action@v1.28.0
         with:

--- a/updatecli/scripts/docusaurus.sh
+++ b/updatecli/scripts/docusaurus.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eux
+
+VERSION="$1"
+if [ -z "$VERSION" ]
+then
+  echo "Empty version provided"
+fi
+
+if [ ! -d "versioned_docs/version-$VERSION" ]
+then
+  yarn run docusaurus docs:version "$VERSION"
+fi

--- a/updatecli/scripts/docusaurus.sh
+++ b/updatecli/scripts/docusaurus.sh
@@ -10,5 +10,7 @@ fi
 
 if [ ! -d "versioned_docs/version-$VERSION" ]
 then
+  # Install dependencies to tmp directory
+  yarn install --frozen-lockfile
   yarn run docusaurus docs:version "$VERSION"
 fi

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -86,3 +86,4 @@ pullrequests:
       mergemethod: squash
       labels:
         - chore
+

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -15,7 +15,7 @@ scms:
 sources:
   epinio:
     name: Get latest Epinio version
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: epinio
       repository: epinio
@@ -28,18 +28,18 @@ targets:
     kind: file
     spec:
       file: docs/installation/install_epinio_cli.md
-      matchPattern: 'https://github.com/epinio/epinio/releases/download/(.*)/'
-      replacePattern: 'https://github.com/epinio/epinio/releases/download/{{ source "epinio" }}/'
-    scmID: default
+      matchpattern: 'https://github.com/epinio/epinio/releases/download/(.*)/'
+      replacepattern: 'https://github.com/epinio/epinio/releases/download/{{ source "epinio" }}/'
+    scmid: default
 
   epinio-version:
     name: 'Update Epinio Version Information'
     kind: file
     spec:
       file: docs/installation/install_epinio_cli.md
-      matchPattern: 'Epinio Version: (.*)'
-      replacePattern: 'Epinio Version: {{ source "epinio" }}'
-    scmID: default
+      matchpattern: 'Epinio Version: (.*)'
+      replacepattern: 'Epinio Version: {{ source "epinio" }}'
+    scmid: default
 
   # Required yarn to be installed
   docusaurus:
@@ -55,7 +55,7 @@ pullrequests:
   default:
     title: '[updatecli] Bump Epinio version used within installation documentation to {{ source "epinio" }}'
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - download-url
       - epinio-version

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -22,6 +22,25 @@ sources:
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
 
+  epinioSubVersion:
+    name: Get latest Epinio version
+    kind: githubrelease
+    spec:
+      owner: epinio
+      repository: epinio
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+    transformers:
+        - trimPrefix: "v"
+        - findSubMatch:
+            # Remove once if we decide to only keep major and minor version such as 0.7
+            # pattern: '^(\d*).(\d*)'
+            pattern: '^(\d*).(\d*).(\d*)'
+            captureindex: 0
+        # Uncomment if we decide to only version based on minor version
+        # so we could have 0.7.x
+        #- addSuffix: ".x"
+
 targets:
   download-url:
     name: 'Update Epinio Installation URL'
@@ -31,10 +50,12 @@ targets:
       matchpattern: 'https://github.com/epinio/epinio/releases/download/(.*)/'
       replacepattern: 'https://github.com/epinio/epinio/releases/download/{{ source "epinio" }}/'
     scmid: default
+    sourceid: epinio
 
   epinio-version:
     name: 'Update Epinio Version Information'
     kind: file
+    sourceid: epinio
     spec:
       file: docs/installation/install_epinio_cli.md
       matchpattern: 'Epinio Version: (.*)'
@@ -46,10 +67,10 @@ targets:
     kind: shell
     name: "Set latest docusaurus version"
     scmid: default
-    sourceid: epinio
+    sourceid: epinioSubVersion
     spec:
       # epinio source value is automatically added to the command as a parameter
-      command: ./updatecli/scripts/docusaurus.sh
+      command: "./updatecli/scripts/docusaurus.sh"
 
 pullrequests:
   default:
@@ -65,4 +86,3 @@ pullrequests:
       mergemethod: squash
       labels:
         - chore
-

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -41,6 +41,16 @@ targets:
       replacePattern: 'Epinio Version: {{ source "epinio" }}'
     scmID: default
 
+  # Required yarn to be installed
+  docusaurus:
+    kind: shell
+    name: "Set latest docusaurus version"
+    scmid: default
+    sourceid: epinio
+    spec:
+      # epinio source value is automatically added to the command as a parameter
+      command: ./updatecli/scripts/docusaurus.sh
+
 pullrequests:
   default:
     title: '[updatecli] Bump Epinio version used within installation documentation to {{ source "epinio" }}'
@@ -49,6 +59,7 @@ pullrequests:
     targets:
       - download-url
       - epinio-version
+      - docusaurus
     spec:
       automerge: true
       mergemethod: squash


### PR DESCRIPTION
This PR adds an updatecli manifest to automatically run ` yarn run docusaurus docs:version x.y.z` if it detects a new version

- [x] Install yarn in the updatecli Gitub Action
- [x] Fix deprecated updatecli syntax

Please note that I took the decision to reuse the same pipeline than the one that update installation url so we only have to review one PR after a new Epinio release. 
I also disabled the `automerge` pull request until we get confident in the process 

I tested that this change work by opening a fake version update on my fork on https://github.com/olblak/epinio-docs/pull/1
I didn't test the github action part