### PR TITLE
Fix updatecli workflow for docusaurus version bump

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -17,24 +17,34 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          cache: yarn
+          #cache: yarn
       
-      - name: Test yarn website
-        run: |
-          which yarn
-          which npm
-      
-      - name: Apply
-        uses: updatecli/updatecli-action@v1.33.0
+      #  https://github.com/actions/setup-node/issues/490
+      - name: Repair NPM  # Update to latest npm and yarn
+        run: "npm install -g npm yarn"
+
+      - name: Install Dependencies
+        run: "yarn install --frozen-lockfile"
+
+      - name: Install Updatecli Binary
+        uses: updatecli/updatecli-action@v2
         with:
-          command: apply
-          flags: "--config ./updatecli/updatecli.d"
+          install-only: true
+
+      - name: Run Updatecli in DryRun
+        run: "updatecli diff --config ./updatecli/updatecli.d"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Updatecli Diff
+        run: "updatecli apply --config ./updatecli/updatecli.d"
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This pull request introduces the two following changes
* Switch updatecli Github Action to v2 relying on Javascript instead of docker
* Yarn/Npm installation workaround

During the last Epinio release, we noticed that we couldn't anymore install yarn using the GitHub Action `actions/setup-node`. It appeared to be a bug on that GitHub Action.
The second issue that we noticed was, Updatecli relied on a GitHub Action of type Docker. And due to that, the updatecli binary was in a isolated container and couldn't use the Docusaurus command. So we had to manually trigger the pipeline to finish the release. Updatecli Github Action is almost ready to have a v2 relying on Javascript

# Test
I used the command `act workflow_dispatch -j updatecli` to test that the workflow was working.
Also I had to comment the line 17 `if: github.ref == 'refs/heads/main'` in the file `.github/workflows/updatecli.yml` so I could run the workflow locally from a branch different than main

# Remark

Please note that the Updatecli Github Action change, is a temporary fix until a decision is done on the Updatecli side https://github.com/updatecli/updatecli-action/issues/76 

Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>