### PR TITLE
Missing Authorization link

### DIFF
--- a/docs/references/references.md
+++ b/docs/references/references.md
@@ -11,4 +11,5 @@ For example all CLI commands and their arguments.
 - [Supported Applications](./supported_applications.md)
 - [Application Manifests](./manifests.md)
 - [Configurations](./configurations.md)
+- [Authorization](./authorization.md)
 - [API](./api.md)

--- a/versioned_docs/version-0.8.0/references/references.md
+++ b/versioned_docs/version-0.8.0/references/references.md
@@ -11,4 +11,5 @@ For example all CLI commands and their arguments.
 - [Supported Applications](./supported_applications.md)
 - [Application Manifests](./manifests.md)
 - [Configurations](./configurations.md)
+- [Authorization](./authorization.md)
 - [API](./api.md)


### PR DESCRIPTION
Fixed missing authorization link in the `References` page.