### PR TITLE
Updated cli docs (--show-password flag)

### DIFF
--- a/docs/references/cli/epinio_settings_show.md
+++ b/docs/references/cli/epinio_settings_show.md
@@ -12,7 +12,8 @@ epinio settings show [flags]
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help            help for show
+      --show-password   Show hidden password
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/pull/1499
---

Updated cli docs with the `--show-password` flag in the `epinio settings show` command.