### PR TITLE
Updated docs for hashed password

### DIFF
--- a/docs/explanations/security.md
+++ b/docs/explanations/security.md
@@ -7,7 +7,7 @@ title: ""
 
 Epinio secures access to its API with TLS and basic authentication.
 
-Use the `epinio settings update` command after installation to extract and save the necessary credentials
+Use the `epinio login [URL]` command after installation to save the necessary credentials
 (user, password) and certificates. The information is stored in Epinio's settings,
 for pickup by other Epinio commands.
 

--- a/docs/howtos/gitjob_push.md
+++ b/docs/howtos/gitjob_push.md
@@ -35,7 +35,7 @@ So the GitJob can authenticate and push correctly, we can upload our Epinio sett
 kubectl create secret generic epinio-creds --from-file=$HOME/.config/epinio/settings.yaml
 ```
 
-This will create a secret containing the settings.yaml that was created locally when you do `epinio settings update`
+This will create a secret containing the settings.yaml that was created locally when you do `epinio login`
 
 ### Setup Sample Project
 

--- a/docs/howtos/install_epinio_on_rancher_desktop.md
+++ b/docs/howtos/install_epinio_on_rancher_desktop.md
@@ -50,7 +50,7 @@ $ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/downloa
 $ helm repo add epinio https://epinio.github.io/helm-charts
 $ helm install epinio -n epinio --create-namespace epinio/epinio --set global.domain=127.0.0.1.sslip.io
 
-$ epinio settings update
+$ epinio login [URL]
 ```
 
 > NOTE: there is currently a [blocking issue](https://github.com/rancher-sandbox/rancher-desktop/issues/576) on Linux which prevent Epinio to push application!

--- a/docs/references/authorization.md
+++ b/docs/references/authorization.md
@@ -17,6 +17,8 @@ After the installation two users are available: `admin` and `epinio`, both with 
 To switch users you need to set the `user` and `pass` keys of the Epinio settings file, located at `~/.config/epinio/settings.yaml`.
 The password has to be base64 encoded. Below, `cGFzc3dvcmQ=` is the base64 encoded version of `password`.
 
+You can also login again with the `epinio login [URL]` command.
+
 
 ```yaml
 api: https://epinio.mydomain.com
@@ -55,7 +57,8 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: mypassword
+  # password is hashed with the Bcrypt algorithm
+  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS" # value is 'password'
 ```
 
 To list the available users you can get the secrets from your cluster with `kubectl`, filtering them with the proper labels:
@@ -92,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: mypassword
+  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -114,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: mypassword
+  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/docs/references/cli/epinio_settings.md
+++ b/docs/references/cli/epinio_settings.md
@@ -37,5 +37,5 @@ epinio settings [flags]
 * [epinio](./epinio.md)	 - Epinio cli
 * [epinio settings colors](./epinio_settings_colors.md)	 - Manage colored output
 * [epinio settings show](./epinio_settings_show.md)	 - Show the current settings
-* [epinio settings update](./epinio_settings_update.md)	 - Update the api location & stored credentials
+* [epinio settings update-ca](./epinio_settings_update-ca.md)	 - Update the api location and CA certificate
 

--- a/docs/references/cli/epinio_settings_update-ca.md
+++ b/docs/references/cli/epinio_settings_update-ca.md
@@ -1,23 +1,23 @@
 ---
 title: ""
-sidebar_label: "epinio settings update"
+sidebar_label: "epinio settings update-ca"
 ---
-## epinio settings update
+## epinio settings update-ca
 
-Update the api location & stored credentials
+Update the api location and CA certificate
 
 ### Synopsis
 
-Update the api location and stored credentials from the current cluster
+Update the api location and CA certificate from the current cluster
 
 ```
-epinio settings update [flags]
+epinio settings update-ca [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help               help for update
+  -h, --help               help for update-ca
   -n, --namespace string   (NAMESPACE) The namespace to use (default "epinio")
 ```
 

--- a/docs/references/command_requirements.md
+++ b/docs/references/command_requirements.md
@@ -8,7 +8,7 @@ title: ""
 | *component* | **API** | **CLI**   |  |
 | *needs*   |   *(kubeconfig)*     | *kubeconfig*    | *settings file* |
 |           |        |               |  |
-| *commands*  | server | settings update | info |
+| *commands*  | server | settings update-ca | info |
 |           |        |                | namespace |
 |           |        |                | configuration |
 |           |        |                | app |

--- a/docs/references/commands.md
+++ b/docs/references/commands.md
@@ -6,6 +6,8 @@ title: ""
 
   - [epinio](cli/epinio.md)
 
+    - [epinio login](cli/epinio_login.md)
+
     - [epinio app](cli/epinio_app.md)
 
       - [epinio app create](cli/epinio_app_create.md)
@@ -27,7 +29,7 @@ title: ""
 
       - [epinio settings colors](cli/epinio_settings_colors.md)
       - [epinio settings show](cli/epinio_settings_show.md)
-      - [epinio settings update](cli/epinio_settings_update.md)
+      - [epinio settings update-ca](cli/epinio_settings_update-ca.md)
 
     - [epinio info](cli/epinio_info.md)
     - [epinio namespace](cli/epinio_namespace.md)

--- a/docs/references/settings.md
+++ b/docs/references/settings.md
@@ -51,6 +51,8 @@ unknown CA and it asks you if you want to trust it and save it
 to the settings so that future invocations of the client are able 
 to verify the actual certificate when talking to Epinio's API server.
 
+The `epinio settings update-ca` updates the API url and the certificate.
+
 ## Commands
 
 The Epinio command line client currently provides 3 commands

--- a/sidebars.js
+++ b/sidebars.js
@@ -171,7 +171,7 @@ const sidebars = {
                   items: [
                     'references/cli/epinio_settings_colors',
                     'references/cli/epinio_settings_show',
-                    'references/cli/epinio_settings_update',
+                    'references/cli/epinio_settings_update-ca',
                   ],
                   link: {
                     type: 'doc',


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1361
---

The `epinio  settings update` command was replaced with the `epinio settings update-ca`.
All the references to the old command where moved to the `epinio login`.