### PR TITLE
Trigger updatecli workflow on epinio release event

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 * * * *'
+  repository_dispatch:
+    types: [epinio-release]
 
 permissions:
   contents: write


### PR DESCRIPTION
The goal is to trigger an updatecli run as soon as Epinio release happen so we can bump all links