### PR TITLE
Added a login subsection to the quickstart

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -39,7 +39,7 @@ epinio login -u admin 'https://epinio.127.0.0.1.sslip.io'
 
 :::tip
 
-If your local Kubernetes cluster restarts, you only need to login again with the command above. Epinio stays installed and the certificates are still valid.
+If your local Kubernetes cluster restarts, Epinio stays installed and the certificates are still valid, so you don't have to login again.
 
 :::
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -29,7 +29,7 @@ cd epinio/assets/
 
 ### Login
 
-The first task to perform after Epinio installation, is to [login](../references/commands/cli/epinio_login.md) with the [`epinio` binary]():
+The first task to perform after Epinio installation, is to [login](../references/commands/cli/epinio_login.md) with the `epinio` binary:
 
 ```shell
 epinio login -u admin 'https://epinio.127.0.0.1.sslip.io'

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -27,6 +27,28 @@ git clone https://github.com/epinio/epinio.git
 cd epinio/assets/
 ```
 
+### Login
+
+The first task to perform after Epinio installation, is to [login](../references/commands/cli/epinio_login.md) with the [`epinio` binary]():
+
+```shell
+epinio login -u admin 'https://epinio.127.0.0.1.sslip.io'
+
+# Trust the certificate by pressing 'y' and 'enter'
+```
+
+:::tip
+
+If your local Kubernetes cluster restarts, you only need to login again with the command above. Epinio stays installed and the certificates are still valid.
+
+:::
+
+You can confirm that you're logged in by checking the Epinio settings:
+
+```shell
+epinio settings show
+```
+
 ### Push an app
 
 There are two ways to push an application:


### PR DESCRIPTION
The `epinio login`  command was missing from the quickstart.

It has been added in the "Push an application" section.