### PR TITLE
Updating footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,15 +105,15 @@ const config = {
             items: [
               {
                 label: 'Stack Overflow',
-                href: 'https://stackoverflow.com/questions/tagged/docusaurus',
+                href: 'https://stackoverflow.com/questions/tagged/epinio',
               },
               {
-                label: 'Discord',
-                href: 'https://discordapp.com/invite/docusaurus',
+                label: 'Slack',
+                href: 'https://rancher-users.slack.com',
               },
               {
                 label: 'Twitter',
-                href: 'https://twitter.com/docusaurus',
+                href: 'https://twitter.com/Rancher_Labs/',
               },
             ],
           },
@@ -126,7 +126,7 @@ const config = {
               },
               {
                 label: 'GitHub',
-                href: 'https://github.com/facebook/docusaurus',
+                href: 'https://github.com/epinio/epinio',
               },
             ],
           },


### PR DESCRIPTION
I noticed that footers links are referencing Docusaurus website, and instead I propose to mention Epinio related website.

* Stackoverflow, to encourage people to use the "epinio" tag
* Twitter to mention the rancherlabs account as we don't have an Epinio one
* Slack to mention the slack workspace, even thought I didn't test locally how it renders

\Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>