### PR TITLE
Updated Paketo docs

### DIFF
--- a/docs/references/supported_applications.md
+++ b/docs/references/supported_applications.md
@@ -24,13 +24,18 @@ If you are not familiar with how buildpacks work, you should have a look at the 
 
 ## Supported buildpacks
 
-Epinio uses the [full stack paketo builder image](https://github.com/paketo-buildpacks/full-stack-release) which means you can make use of any of the buildpacks
-documented here: https://paketo.io/docs/buildpacks/language-family-buildpacks/
+Epinio uses the [Paketo full builder image](https://github.com/paketo-buildpacks/full-builder) which means you can make use of any of the buildpacks
+documented here: https://paketo.io/docs/concepts/builders/#full
 
 The various buildpacks provide various configuration options. You can read on how to generally configure a buildpack here: https://paketo.io/docs/buildpacks/configuration/
 Each buildpack may support more configuration options, so you may have to read the documentation of the buildpacks you are interested in.
 
-E.g. [Instructions on how to add custom php.ini files for php-web buildpack](https://github.com/paketo-buildpacks/php-web#configuring-custom-ini-files)
+E.g.
+- [Instructions on how to add custom php.ini files for php-web buildpack](https://github.com/paketo-buildpacks/php-web#configuring-custom-ini-files)
+- [Go Buildpack](https://github.com/paketo-buildpacks/go)
+
+Note: if your application needs to explicit a particular command to start, you should probably provide a [Procfile](https://devcenter.heroku.com/articles/procfile) in order to use the [Procfile Buildpack](https://github.com/paketo-buildpacks/procfile).
+
 
 ## Detailed push process
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -79,8 +79,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-0.6.2/tutorials/quickstart.md
+++ b/versioned_docs/version-0.6.2/tutorials/quickstart.md
@@ -55,8 +55,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-0.7.1/tutorials/quickstart.md
+++ b/versioned_docs/version-0.7.1/tutorials/quickstart.md
@@ -56,8 +56,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-0.8.0/tutorials/quickstart.md
+++ b/versioned_docs/version-0.8.0/tutorials/quickstart.md
@@ -56,8 +56,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-0.9.0/tutorials/quickstart.md
+++ b/versioned_docs/version-0.9.0/tutorials/quickstart.md
@@ -56,8 +56,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-1.0.0/tutorials/quickstart.md
+++ b/versioned_docs/version-1.0.0/tutorials/quickstart.md
@@ -57,8 +57,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-1.1.0/tutorials/quickstart.md
+++ b/versioned_docs/version-1.1.0/tutorials/quickstart.md
@@ -57,8 +57,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-1.2.0/tutorials/quickstart.md
+++ b/versioned_docs/version-1.2.0/tutorials/quickstart.md
@@ -79,8 +79,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 

--- a/versioned_docs/version-1.3.0/references/supported_applications.md
+++ b/versioned_docs/version-1.3.0/references/supported_applications.md
@@ -24,13 +24,18 @@ If you are not familiar with how buildpacks work, you should have a look at the 
 
 ## Supported buildpacks
 
-Epinio uses the [full stack paketo builder image](https://github.com/paketo-buildpacks/full-stack-release) which means you can make use of any of the buildpacks
-documented here: https://paketo.io/docs/buildpacks/language-family-buildpacks/
+Epinio uses the [Paketo full builder image](https://github.com/paketo-buildpacks/full-builder) which means you can make use of any of the buildpacks
+documented here: https://paketo.io/docs/concepts/builders/#full
 
 The various buildpacks provide various configuration options. You can read on how to generally configure a buildpack here: https://paketo.io/docs/buildpacks/configuration/
 Each buildpack may support more configuration options, so you may have to read the documentation of the buildpacks you are interested in.
 
-E.g. [Instructions on how to add custom php.ini files for php-web buildpack](https://github.com/paketo-buildpacks/php-web#configuring-custom-ini-files)
+E.g.
+- [Instructions on how to add custom php.ini files for php-web buildpack](https://github.com/paketo-buildpacks/php-web#configuring-custom-ini-files)
+- [Go Buildpack](https://github.com/paketo-buildpacks/go)
+
+Note: if your application needs to explicit a particular command to start, you should probably provide a [Procfile](https://devcenter.heroku.com/articles/procfile) in order to use the [Procfile Buildpack](https://github.com/paketo-buildpacks/procfile).
+
 
 ## Detailed push process
 

--- a/versioned_docs/version-1.3.0/tutorials/quickstart.md
+++ b/versioned_docs/version-1.3.0/tutorials/quickstart.md
@@ -79,8 +79,7 @@ We also provide information about the more advanced [git model](../explanations/
 
 ***
 
-###### Note: If you want to know the details of the `epinio push`
-process, please read the [detailed push docs](../explanations/detailed-push-process.md)
+###### Note: If you want to know the details of the `epinio push` process, please read the [detailed push docs](../explanations/detailed-push-process.md)
 
 ***
 


### PR DESCRIPTION
Added procfile, updated Paketo docs and fixed quickstart newline.

Fixes #183 

---

Here the page where we describe a bit more the Paketo Buildpacks: https://deploy-preview-186--epinio-docs-staging.netlify.app/references/supported_applications

I've seen it going through the doc at the [Quickstart](https://deploy-preview-186--epinio-docs-staging.netlify.app/tutorials/quickstart#push-an-app), so it should be visible enough.

I've updated it only in the current and v.1.3.0 doc though, should we go back also on older releases? Maybe from the 1.0.0.