### PR TITLE
Extending epinio settings update-ca to epinio installation page

### DIFF
--- a/docs/installation/install_epinio.md
+++ b/docs/installation/install_epinio.md
@@ -115,6 +115,8 @@ Read more on how to setup DNS here: [DNS setup](./dns_setup.md)
 
 > *NOTE*: If you're deploying Epinio in a "localhost" environment, you can use a "[magic domain name](./magicDNS_setup.md)".
 
+> *NOTE II*: in case the installation fails due to an expired certificate (for instance if you have previously initialized the epinio cli on a machine for a different cluster) please consider executing epinio `epinio settings update-ca`.  More info at: [epinio-settings-update-ca](https://docs.epinio.io/references/commands/cli/settings/epinio_settings_update-ca#epinio-settings-update-ca)
+
 ## Installation on Specific Kubernetes Offerings
 
 Installing Epinio is a standard process as explained above, however you might need to configure it for a specific Kubernetes cluster.

--- a/versioned_docs/version-1.4.0/installation/install_epinio.md
+++ b/versioned_docs/version-1.4.0/installation/install_epinio.md
@@ -115,6 +115,8 @@ Read more on how to setup DNS here: [DNS setup](./dns_setup.md)
 
 > *NOTE*: If you're deploying Epinio in a "localhost" environment, you can use a "[magic domain name](./magicDNS_setup.md)".
 
+> *NOTE II*: in case the installation fails due to an expired certificate (for instance if you have previously initialized the epinio cli on a machine for a different cluster) please consider executing epinio `epinio settings update-ca`.  More info at: [epinio-settings-update-ca](https://docs.epinio.io/references/commands/cli/settings/epinio_settings_update-ca#epinio-settings-update-ca)
+
 ## Installation on Specific Kubernetes Offerings
 
 Installing Epinio is a standard process as explained above, however you might need to configure it for a specific Kubernetes cluster.


### PR DESCRIPTION
Related to https://github.com/epinio/docs/issues/189

Adds a note on the Epinio installation page about the use of `epinio settings update-ca` that may be useful.