### PR TITLE
Update EKS documentation with additional requirements for v1.23+

### DIFF
--- a/docs/howtos/install_epinio_on_eks.md
+++ b/docs/howtos/install_epinio_on_eks.md
@@ -16,7 +16,7 @@ This how-to was written using the following versions:
 :::caution *) Additional requirements for EKS v1.23 and v1.24
 
 
-* From EKS v1.23 there is a need to configure and install an out-of-tree AWS EBS CSI driver as a addon into your EKS cluster. Please refer to this [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) for more details.
+* Since EKS v1.23 it is necessary to configure and install an out-of-tree AWS EBS CSI driver as an addon into your EKS cluster. Please refer to this [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) for more details.
 * Since EKS v1.24, when the `dockershim` CRI support has been dropped and replaced by `containerd` (supports only trusted HTTPS registries by default), there is a need to allow pulling epinio's app container images from Internal Epinio HTTP Registry. The following configuration must be done on all EKS nodes prior deploying an Epinio app:
 
     ```shell

--- a/docs/howtos/install_epinio_on_eks.md
+++ b/docs/howtos/install_epinio_on_eks.md
@@ -42,7 +42,7 @@ This how-to was written using the following versions:
 
 ## Create EKS Kubernetes Cluster
 
-*Ensure that you ran **[aws configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)** before you proceed with the steps bellow.*
+*Ensure that you ran **[aws configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)** before you proceed with the steps below.*
 
 ```shell
 eksctl create cluster \

--- a/docs/howtos/install_epinio_on_eks.md
+++ b/docs/howtos/install_epinio_on_eks.md
@@ -29,7 +29,7 @@ This how-to was written using the following versions:
     EOF
     ```
 
-    Eventually you may modify the node count and apply [this manifest](https://raw.githubusercontent.com/epinio/epinio/main/scripts/eks-cri-allow-http-registries.yaml) which will do the nodes configuration for you.
+    Instead of doing this manually it should be easier to simply apply [this manifest](https://raw.githubusercontent.com/epinio/epinio/main/scripts/eks-cri-allow-http-registries.yaml) which will do the nodes configuration for you, after editing it to use the correct node count.
 
 :::
 

--- a/docs/howtos/install_epinio_on_eks.md
+++ b/docs/howtos/install_epinio_on_eks.md
@@ -17,7 +17,7 @@ This how-to was written using the following versions:
 
 
 * Since EKS v1.23 it is necessary to configure and install an out-of-tree AWS EBS CSI driver as an addon into your EKS cluster. Please refer to this [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) for more details.
-* Since EKS v1.24, when the `dockershim` CRI support has been dropped and replaced by `containerd` (supports only trusted HTTPS registries by default), there is a need to allow pulling epinio's app container images from Internal Epinio HTTP Registry. The following configuration must be done on all EKS nodes prior deploying an Epinio app:
+* Since EKS v1.24 it is necessary to explicitly allow the pulling of Epinio's app container images from its internal HTTP registry, due to the removal of `dockershim` CRI support and its replacement by `containerd`, which supports only trusted HTTPS registries by default. The following configuration must be done on all EKS nodes prior deploying an Epinio app:
 
     ```shell
     mkdir -p /etc/containerd/certs.d/127.0.0.1:30500

--- a/docs/howtos/install_epinio_on_public_cloud.md
+++ b/docs/howtos/install_epinio_on_public_cloud.md
@@ -34,12 +34,15 @@ In AKS, Epinio must be installed with an external registry because due to a [cha
 
 ### EKS prerequisites
 
-* Epinio has been tested with EKS version **v1.21**
+* Epinio has been tested with EKS version **v1.22**, **v1.23** and **v1.24**
 * To just try out Epinio, e.g. 2 **t3a.large** nodes are sufficient
 
 ### Create an EKS cluster
 
 If you do not have an existing cluster, follow the [quickstart](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) to create an EKS cluster.
+
+Details can be found in the dedicated [EKS documentation](./install_epinio_on_eks.md).
+
 </details>
 
 <details>


### PR DESCRIPTION
Ref. https://github.com/epinio/epinio/issues/2083

I updated the EKS docs and  removed things which confused me :)

I tested following on epinio devel v1.6.2+ with updated epinio CLI bin (missing cert for app exec):
* epinio deployed on EBS v1.23 (v1.24 tested by CI) with valid route53 domain zone, ELB and nginx-ingress, `letsencrypt-production` as tlsIssue (I removed the misleading `letsencrypt-epinio` part)
* epinio DEX UI login
* epinio login --oidc ...
* epinio push app ...
* epinio app exec
