### PR TITLE
Moved Gitea custom builder how-to to tutorials

### DIFF
--- a/docs/howtos/custom_builder.md
+++ b/docs/howtos/custom_builder.md
@@ -86,7 +86,7 @@ epinio push -n myapp -p app_directory --builder-image myorg/epicustombuilder:lat
 ## More examples
 
 You can find a more complete example on how to build and deploy a custom builder here:
-- [Deploy Gitea with a custom builder image](./custom_builder_go.md)
+- [Deploy Gitea with a custom builder image](../tutorials/custom_builder_go.md)
 
 ## Reference
 

--- a/docs/tutorials/custom_builder_go.md
+++ b/docs/tutorials/custom_builder_go.md
@@ -1,12 +1,11 @@
 ---
-sidebar_label: "Deploy Gitea with a custom builder image"
-sidebar_position: 14
+sidebar_label: "Epinio Journey: Deploy complex applications with a custom builder image"
 title: ""
 ---
 
 # Deploy Gitea with a custom builder image
 
-This How To will show you how to deploy Gitea with Epinio and a custom builder.
+While you likely won't use Epinio to build and deploy Gitea, we are using it to show how to build a more complex application with Epinio.
 
 [Gitea](https://github.com/go-gitea/gitea) is a self-hosted Git service. It is written in Go and Node.js.
 

--- a/docs/tutorials/custom_builder_go.md
+++ b/docs/tutorials/custom_builder_go.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: "Epinio Journey: Deploy complex applications with a custom builder image"
+sidebar_position: 4
 title: ""
 ---
 

--- a/docs/tutorials/namespace-tutorial.md
+++ b/docs/tutorials/namespace-tutorial.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+title: ""
+---
+
 # Namespaces
 ## Introduction
 This document explains the basics of working with namespaces. It assumes that Epinio is installed. If this is not the case please visit [Install Epinio](docs/installation/install_epinio.md) first.

--- a/docs/tutorials/single-dev-workflow.md
+++ b/docs/tutorials/single-dev-workflow.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: "Epinio Journey: Single Dev Workflow"
+sidebar_position: 3
 title: ""
 ---
 


### PR DESCRIPTION
This PR moves the Gitea custom builder deploy HowTo to the Tutorials section, with a new title.