### PR TITLE
Bring Namespaces title back

### DIFF
--- a/docs/tutorials/namespace-tutorial.md
+++ b/docs/tutorials/namespace-tutorial.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: ""
+title: "Namespaces"
 ---
 
 # Namespaces


### PR DESCRIPTION
The page had no Title set in docusaurus meta so the sidebar menu contained just an link with empty Title string.