### PR TITLE
Automate cert-manager update

### DIFF
--- a/updatecli/updatecli.d/cert-manager.yaml
+++ b/updatecli/updatecli.d/cert-manager.yaml
@@ -1,0 +1,50 @@
+name: Bump Cert-manager version in installation documentation
+
+sources:
+  cert-manager:
+    name: Get latest Cert manager version
+    kind: githubrelease
+    spec:
+      owner: cert-manager
+      repository: cert-manager
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      typefilter:
+        latest: true
+
+targets:
+  download-url:
+    name: 'Update Epinio Installation URL'
+    kind: file
+    spec:
+      files: 
+        - docs/tutorials/single-dev-workflow.md
+        - docs/howtos/install_epinio_on_rancher_desktop.md
+      matchpattern: 'https://github.com/cert-manager/cert-manager/releases/download/(.*)/'
+      replacepattern: 'https://github.com/cert-manager/cert-manager/releases/download/{{ source "cert-manager" }}/'
+    scmid: default
+    disablesourceinput: true
+
+actions:
+  default:
+    title: 'Bump cert-manager version used within installation documentation to {{ source "cert-manager" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      labels:
+        - chore
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: epinio-bot
+      email: bot@epinio.io
+      owner: epinio
+      repository: docs
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+


### PR DESCRIPTION
While looking at the documentation, I noticed the cert-manager installation link was really old.
This manifest will automatically track the latest version and open a PR

Tested locally 

<details><summary> local execution</summary>

```

 >  updatecli diff --config updatecli/updatecli.d/cert-manager.yaml        


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/cert-manager.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



###########################################################
# BUMP CERT-MANAGER VERSION IN INSTALLATION DOCUMENTATION #
###########################################################


SOURCES
=======

cert-manager
------------
Searching for version matching pattern "latest"
✔ GitHub release version "v1.12.3" found matching pattern "latest" of kind "latest"


CHANGELOG:
----------

Release published on the 2023-07-26 12:33:55 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.12.3

## Changes by Kind

### Bugfixes

- BUGFIX[cainjector]: 1-character bug was causing invalid log messages and a memory leak (#6235, @jetstack-bot)



TARGETS
========

download-url
------------

**Dry Run enabled**

⚠ - Updated to [dry run] content "" in file "docs/tutorials/single-dev-workflow.md"

Updated to [dry run] content "" in file "docs/howtos/install_epinio_on_rancher_desktop.md"


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:



⚠ Bump Cert-manager version in installation documentation:
	Source:
		✔ [cert-manager] Get latest Cert manager version
	Target:
		⚠ [download-url] Update Epinio Installation URL


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

```
</details>