### PR TITLE
chore: updated gitconfig documentation to use the new command ensemble

### DIFF
--- a/docs/howtos/customization/create_git_configuration.md
+++ b/docs/howtos/customization/create_git_configuration.md
@@ -6,53 +6,31 @@ title: ""
 
 # Create a Git Configuration
 
-As described [in the Git Configuration reference page](../../references/git_configuration.md), Epinio Git Configurations are Kubernetes secrets with a particular label.
+As described [in the Git Configuration reference page](../../references/git_configuration.md),
+Epinio Git Configurations are Kubernetes secrets with a particular label.
 
-To create one you apply a Secret resource to your Kubernetes cluster:
+Creation is done with the
+[epinio gitconfig create](../../references/commands/cli/gitconfig/epinio_gitconfig_create.md)
+command.
 
-```yaml
-apiVersion: v1 
-kind: Secret 
-type: Opaque 
-metadata: 
-  labels: 
-    epinio.io/api-git-credentials: "true"
-  name: github-epinio-example-go-configuration 
-  namespace: epinio 
-stringData:
-  url: https://github.com
-  provider: github
-  username: "myuser" 
-  password: "abcde12345" 
-  userOrg: epinio 
-  repo: example-go 
-  skipSSL: true 
-  certificate: |
-    -----BEGIN CERTIFICATE-----
-    MIIBaTCCAQ+gAwIBAgIRAN4tvwEOKogvOzT/KccL8t8wCgYIKoZIzj0EAwIwFDES
-    ***************
-    -----END CERTIFICATE-----
-```
-
-The only required field is the `url`, so if you want for example to just skip the SSL verification for a particular provider you can create a simpler secret, and label it:
+For example:
 
 ```bash
-kubectl create secret generic mygit-config -n epinio --from-literal=url=https://gitlab.mydomain.com --from-literal=skipSSL=true
-kubectl label secret mygit-config -n epinio "epinio.io/api-git-credentials=true"
+epinio gitconfig create github-epinio-example-go-configuration https://github.com \
+    --git-provider github	\
+    --user-org 	   epinio	\
+    --repository   example-go	\
+    --skip-ssl	   		\
+    --username 	   myuser	\
+    --password 	   abcde12345	\
+    --cert-file	   /path/to/some/certfile
 ```
 
-or apply this resource:
+The only required arguments are the name of the git configuration, and the repository url.
+Everything else is optional, and specified through flags.
 
-```yaml
-apiVersion: v1 
-kind: Secret 
-type: Opaque 
-metadata: 
-  labels: 
-    epinio.io/api-git-credentials: "true"
-  name: mygit-config 
-  namespace: epinio 
-stringData:
-  url: https://gitlab.mydomain.com
-  skipSSL: true 
+If, for example, we only have to skip the SSL configuration for a particular provider just use:
+
+```bash
+epinio gitconfig create mygit-config https://gitlab.mydomain.com --skip-ssl
 ```

--- a/docs/references/git_configuration.md
+++ b/docs/references/git_configuration.md
@@ -5,33 +5,89 @@ title: ""
 
 # Git Configuration
 
+## Overview
+
 Starting with version **1.10.0**, Epinio supports Git configurations.
 
-Configurations provide information enabling the cloning of private repositories, disabling of SSL verification, or extending verification through a custom bundle of certificates. All on a per git host (+user/org, +repository) basis.
+Configurations enable cloning of private repositories, disabling of SSL verification, and/or
+extending verification through a custom bundle of certificates.
+
+This is done on a per git host (+user/org, +repository) basis.
+
+Management, including creation, is done through the
+[epinio gitconfig](commands/cli/gitconfig/epinio_gitconfig.md)
+command ensemble.
+
+## Matching process
+
+When importing from a git repository Epinio will use the most specific matching configuration, if
+there is any.
+
+This means that a matching configuration specifying url, user/organization, and repository has
+priority over matching configurations specifying only url and user/organization, or even just the
+url.
+
+If no configuration is found then the cloning from the Git repository will run without any
+customization.
+
+## Github/Gitlab specialities
+
+The public Github and Gitlab mega repositories support the use of a `PAT` (Personal Access Token)
+over a plain combination of user and password.
+
+When using a PAT it has to be set as the password, and the user can be set to anything except empty.
+
+:::tip
+It is useful to set it to the username used to generate the token.
+:::
+
+## Detailed specification
+
+:::note
+Regular users have no need to know the information in this section.
+It is useful to operators though, helping in debugging and inspection.
+:::
 
 A Git configuration is a Kubernetes secret with the `epinio.io/api-git-credentials: "true"` label.
 
-The available fields are:
+The fields are:
 
-- **url (required):** the host of the git instance
-- **provider:** one of `github`, `gitlab`, `git`, `github_enterprise`, `gitlab_enterprise`
-- **username:** used during the Basic Authentication 
-- **password:** used during the Basic Authentication
-- **userOrg:** used to restrict the configuration to a specific organization/project 
-- **repo:** used to restrict the configuration to a specific repository 
-- **skipSSL:** used to skip the SSL verification 
-- **certificate:** the CA bundle to load for the SSL verification with self-signed certificates
-
-
-When importing from a git repository Epinio will look for the the most specific matching configuration, if any. For example when trying to clone `https://github.com/myusername/myrepo` Epinio will first look for a configuration having the `https://github.com` *URL*, a `myusername` *userOrg* and a `myrepo` *repo*.
-If not found it will look for a configuration having the `https://github.com` *URL* and a `myusername` *userOrg*. And finally it will look for a configuration having just the `https://github.com` *URL*. If no configuration is found the clone from the Git repository will run without any customization.
-
+|Field		|Required|Meaning									|
+|---		|---	|---										|
+|`url`		|yes	| the host of the git instance							|
+|`provider`	|	| one of `github`, `gitlab`, `git`, `github_enterprise`, `gitlab_enterprise`	|
+|`username`	|	| used during the Basic Authentication						|
+|`password`	|	| used during the Basic Authentication						|
+|`userOrg`	|	| used to restrict the configuration to a specific organization/project		|
+|`repo`		|	| used to restrict the configuration to a specific repository			|
+|`skipSSL`	|	| used to skip the SSL verification						|
+|`certificate`	|	| the CA bundle to load for the SSL verification with self-signed certificates	|
 
 All the fields, except for the URL, are optional.
 
-For Github and Gitlab you can create a PAT (Personal Access Token) and use it in the `password` field. You will need to provide a `username` as well, but it can be anything. As a suggestion it's useful to use the username used to generate the token.
+## Example:
 
-This is an example of a complete Git Configuration secret:
+Invoking the commands
+
+```bash
+cat > certfile <<EOF
+-----BEGIN CERTIFICATE-----
+MIIBaTCCAQ+gAwIBAgIRAN4tvwEOKogvOzT/KccL8t8wCgYIKoZIzj0EAwIwFDES
+***************
+-----END CERTIFICATE-----
+EOF
+
+epinio gitconfig create github-epinio-example-go-configuration https://github.com \
+    --git-provider github	\
+    --user-org 	   epinio	\
+    --repository   example-go	\
+    --skip-ssl	   		\
+    --username 	   myuser	\
+    --password 	   abcde12345	\
+    --cert-file	   certfile
+```
+
+will generate the secret
 
 ```yaml
 apiVersion: v1 
@@ -57,4 +113,4 @@ stringData:
     -----END CERTIFICATE-----
 ```
 
-If you are looking for some examples you can check the [How-to](../howtos/customization/create_git_configuration.md).
+For more examples check the [How-to](../howtos/customization/create_git_configuration.md).

--- a/docs/references/git_configuration.md
+++ b/docs/references/git_configuration.md
@@ -38,14 +38,14 @@ over a plain combination of user and password.
 When using a PAT it has to be set as the password, and the user can be set to anything except empty.
 
 :::tip
-It is useful to set it to the username used to generate the token.
+For reference, it is useful to set it to the username used to generate the token.
 :::
 
 ## Detailed specification
 
 :::note
-Regular users have no need to know the information in this section.
-It is useful to operators though, helping in debugging and inspection.
+This section contains information useful to operators for debugging and inspection. 
+Regular users should not normally need to consult this section.
 :::
 
 A Git configuration is a Kubernetes secret with the `epinio.io/api-git-credentials: "true"` label.


### PR DESCRIPTION
fix #305 

rewrite the gitconfig docs, use the gitconfig command instead of direct access to the cluster