### PR TITLE
Fixed missing escape for dollar sign in command

### DIFF
--- a/docs/references/authorization.md
+++ b/docs/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-0.9.0/references/authorization.md
+++ b/versioned_docs/version-0.9.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.0.0/references/authorization.md
+++ b/versioned_docs/version-1.0.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.1.0/references/authorization.md
+++ b/versioned_docs/version-1.1.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.10.0/references/authorization.md
+++ b/versioned_docs/version-1.10.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.2.0/references/authorization.md
+++ b/versioned_docs/version-1.2.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.3.0/references/authorization.md
+++ b/versioned_docs/version-1.3.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.4.0/references/authorization.md
+++ b/versioned_docs/version-1.4.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.5.0/references/authorization.md
+++ b/versioned_docs/version-1.5.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.5.1/references/authorization.md
+++ b/versioned_docs/version-1.5.1/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.5.2/references/authorization.md
+++ b/versioned_docs/version-1.5.2/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.6.0/references/authorization.md
+++ b/versioned_docs/version-1.6.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.6.1/references/authorization.md
+++ b/versioned_docs/version-1.6.1/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.6.2/references/authorization.md
+++ b/versioned_docs/version-1.6.2/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.7.0/references/authorization.md
+++ b/versioned_docs/version-1.7.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.7.1/references/authorization.md
+++ b/versioned_docs/version-1.7.1/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.8.0/references/authorization.md
+++ b/versioned_docs/version-1.8.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.8.1/references/authorization.md
+++ b/versioned_docs/version-1.8.1/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2

--- a/versioned_docs/version-1.9.0/references/authorization.md
+++ b/versioned_docs/version-1.9.0/references/authorization.md
@@ -95,7 +95,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 EOF
 ```
 
@@ -117,7 +117,7 @@ metadata:
   namespace: epinio
 stringData:
   username: myuser
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  password: "\$2a\$10\$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace
     workspace2


### PR DESCRIPTION
Command was not working properly for a missing escape.

Fixed also in previous versioned docs.