### PR TITLE
Two small fixes in recent work.

### DIFF
--- a/docs/howtos/use-develop/app_recover.md
+++ b/docs/howtos/use-develop/app_recover.md
@@ -13,8 +13,8 @@ Epinio uses 3 Kubernetes CRDs to manage its service catalog entries, app charts,
 
 When deleting a CRD Kubernetes also deletes all associated CRs.
 
-If, during an upgrade of an Epinio installation Epinio's CRDs were deleted, this means that
-that Epinio's service catalog entries, custom app charts, and applications data are **gone**.
+If, during an upgrade of an Epinio installation Epinio's CRDs were deleted, this means that Epinio's
+service catalog entries, custom app charts, and applications data are **gone**.
 
 Regarding the latter note that the active parts of Epinio applications use regular Kubernetes
 resources, and thus keep running during such an operation. Epinio however will lose track of these

--- a/docs/references/cert-manager.md
+++ b/docs/references/cert-manager.md
@@ -156,4 +156,4 @@ openssl x509 -in registry.pem -text | grep -A1 'Subject Alternative Name'
 ### Applications
 
 Under normal circumstances applications request their ingress certificates from CM.
-Without CM use of [routing secrets](customization/routing_secrets.md) becomes **manadatory**.
+Without CM use of [routing secrets](customization/routing_secrets.md) becomes **mandatory**.

--- a/docs/references/cert-manager.md
+++ b/docs/references/cert-manager.md
@@ -151,3 +151,9 @@ openssl x509 -in registry.pem -text | grep -A1 'Subject Alternative Name'
 >             X509v3 Subject Alternative Name: 
 >                DNS:registry.suse.dev
 ```
+
+
+### Applications
+
+Under normal circumstances applications request their ingress certificates from CM.
+Without CM use of [routing secrets](customization/routing_secrets.md) becomes **manadatory**.


### PR DESCRIPTION
fix: missing reference to mandatory use of routing secrets when CM is disabled.
fix: double `that that` in app recovery.