### PR TITLE
Update google tag for GA4

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         googleAnalytics: {
-          trackingID: 'UA-56382716-12',
+          trackingID: 'G-3JFJM9K7DT',
           anonymizeIP: true,
         },
       }),


### PR DESCRIPTION
Generate analytics under Google GA4, rather than the sunsetted UA. may provide useful data for future decisions.