### PR TITLE
Revert "Update google tag for GA4"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         googleAnalytics: {
-          trackingID: 'G-3JFJM9K7DT',
+          trackingID: 'UA-56382716-12',
           anonymizeIP: true,
         },
       }),


### PR DESCRIPTION
Reverts epinio/docs#395.

It didn't seem to work. Some more investigation is needed.