### PR TITLE
Remove howdoi.website (it no longer works)

### DIFF
--- a/docs/howtos/other/certificate_issuers.md
+++ b/docs/howtos/other/certificate_issuers.md
@@ -146,9 +146,9 @@ Example:
     name: epinio
     namespace: epinio
   spec:
-    commonName: epinio.172.27.0.2.omg.howdoi.website
+    commonName: epinio.172.27.0.2.sslip.io
     dnsNames:
-    - epinio.172.27.0.2.omg.howdoi.website
+    - epinio.172.27.0.2.sslip.io
     issuerRef:
       kind: ClusterIssuer
       name: epinio-ca
@@ -163,9 +163,9 @@ Example:
   type: kubernetes.io/tls
   metadata:
     annotations:
-      cert-manager.io/alt-names: epinio.172.27.0.2.omg.howdoi.website
+      cert-manager.io/alt-names: epinio.172.27.0.2.sslip.io
       cert-manager.io/certificate-name: epinio
-      cert-manager.io/common-name: epinio.172.27.0.2.omg.howdoi.website
+      cert-manager.io/common-name: epinio.172.27.0.2.sslip.io
       cert-manager.io/ip-sans: ""
       cert-manager.io/issuer-group: ""
       cert-manager.io/issuer-kind: ClusterIssuer
@@ -196,7 +196,7 @@ Example:
     namespace: epinio
   spec:
     rules:
-    - host: epinio.172.27.0.2.omg.howdoi.website
+    - host: epinio.172.27.0.2.sslip.io
       http:
         paths:
         - backend:
@@ -208,7 +208,7 @@ Example:
           pathType: ImplementationSpecific
     tls:
     - hosts:
-      - epinio.172.27.0.2.omg.howdoi.website
+      - epinio.172.27.0.2.sslip.io
       secretName: epinio-tls
   ```
 

--- a/docs/howtos/other/port_forwarding.md
+++ b/docs/howtos/other/port_forwarding.md
@@ -47,7 +47,7 @@ Application: samplejava
 | StageId              | cac0d6fec92e0a1f                            |
 | Age                  | 2m50s                                       |
 | Active Routes        |                                             |
-|                      | samplejava.172.19.0.4.omg.howdoi.website    |
+|                      | samplejava.172.19.0.4.sslip.io    |
 | Desired Instances    |                                           1 |
 | Bound Configurations |                                             |
 | Environment          |                                             |

--- a/docs/howtos/use-develop/app_recover.md
+++ b/docs/howtos/use-develop/app_recover.md
@@ -66,8 +66,8 @@ spec:
   origin:
     path: /home/work/SUSE/dev/epinio/assets/sample-app
   routes:
-  - fox.172.18.0.4.omg.howdoi.website
-  - foxy.172.18.0.4.omg.howdoi.website
+  - fox.172.18.0.4.sslip.io
+  - foxy.172.18.0.4.sslip.io
   stageid: 1642fcf755ab41e8
 ```
 
@@ -154,8 +154,8 @@ The ingresses for an application `<name>` are named `r<name>-...` and the listed
 ```bash
 % kubectl get ingress -n workspace
 NAME                                                              CLASS     HOSTS                                [...]
-rfox-fox1721804omghowd-5af9c73b3c19f041d061042e158408a5275b015e   traefik   fox.172.18.0.4.omg.howdoi.website    [...]
-rfox-foxy1721804omghow-22ecdc59ff0c5c7b0f328802c6abea7739c2a388   traefik   foxy.172.18.0.4.omg.howdoi.website   [...]
+rfox-fox1721804omghowd-5af9c73b3c19f041d061042e158408a5275b015e   traefik   fox.172.18.0.4.sslip.io    [...]
+rfox-foxy1721804omghow-22ecdc59ff0c5c7b0f328802c6abea7739c2a388   traefik   foxy.172.18.0.4.sslip.io   [...]
 ```
 
 Not recoverable is the `origin` data. It is stored nowhere else in the system.

--- a/docs/installation/other_inst_scenarios/install_epinio_on_k3s.md
+++ b/docs/installation/other_inst_scenarios/install_epinio_on_k3s.md
@@ -43,7 +43,7 @@ Then, continue with the [Epinio installation process](../../installation/install
 
 If you experience issues with DNS resolution, if, for example, you have something like this in your logs:
 ```
-dial tcp: lookup epinio-registry.192.168.1.10.omg.howdoi.website on 10.43.0.10:53: no such host
+dial tcp: lookup epinio-registry.192.168.1.10.sslip.io on 10.43.0.10:53: no such host
 ```
 
 You can try to install K3s with this known-to-work DNS server:

--- a/docs/installation/other_inst_scenarios/install_epinio_on_rke.md
+++ b/docs/installation/other_inst_scenarios/install_epinio_on_rke.md
@@ -79,7 +79,7 @@ Perform the following steps on your RKE2 node before installing Epinio:
 
 ## Installation
 
-For evaluation environments we recommend that you setup Epinio Ingress resources with a wildcard DNS service such as `omg.howdoi.website`, `sslip.io`, or `nip.io` that points to the `INTERNAL-IP` address of your kubernetes node.
+For evaluation environments we recommend that you setup Epinio Ingress resources with a wildcard DNS service such as `sslip.io`, `sslip.io`, or `nip.io` that points to the `INTERNAL-IP` address of your kubernetes node.
 
 For production environments you should configure an external load-balancer solution.
 It should listen on a public IP with an associated public FQDN domain.
@@ -91,7 +91,7 @@ There are two ways of installing DNS for Epinio:
 
     For test environments.
     This should work on any kubernetes distribution.
-    Epinio will try to create a magic wildcard DNS domain, for example, **10.0.0.1.omg.howdoi.website**.
+    Epinio will try to create a magic wildcard DNS domain, for example, **10.0.0.1.sslip.io**.
 
 1. [DNS setup](../../installation/dns_setup.md)
 

--- a/docs/installation/wildcardDNS_setup.md
+++ b/docs/installation/wildcardDNS_setup.md
@@ -15,15 +15,14 @@ By "wildcard" we mean a domain that will always resolve to the IP address that i
 So, it is a record in a DNS zone that will match requests for non-existent sub-domains.
 There are a variety of free services doing this:
 
-- omg.howdoi.website
 - sslip.io
 - nip.io
 
 As examples, all the following domains resolve to `127.0.0.1`:
 
-- `127.0.0.1.omg.howdoi.website`
-- `subdomain.127.0.0.1.omg.howdoi.website`
-- `subsub.subdomain.127.0.0.1.omg.howdoi.website`
+- `127.0.0.1.sslip.io`
+- `subdomain.127.0.0.1.sslip.io`
+- `subsub.subdomain.127.0.0.1.sslip.io`
 
 You can use domains like these as a wildcard system domain for Epinio.
 
@@ -44,7 +43,7 @@ This stops a malicious website from probing the local network for hosts.
 
 This includes anything using [dnsmasq](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html) with `stop-dns-rebind`. Examples are [pfSense](https://docs.netgate.com/pfsense/en/latest/services/dns/rebinding.html) or NetworkManager.
 
-If you still want to use the default wildcard DNS, you'll have to whitelist `omg.howdoi.website`, or other providers, in your local DNS server.
+If you still want to use the default wildcard DNS, you'll have to whitelist `sslip.io`, or other providers, in your local DNS server.
 
 ### Cluster running in a VM
 

--- a/docs/references/authentication_oidc.md
+++ b/docs/references/authentication_oidc.md
@@ -16,7 +16,7 @@ epinio login --oidc https://epinio.mydomain.com
 If you are using the `epinio` cli on a machine without a browser you can provide the `--prompt` flag. This will give you the url of a web page where you can authenticate even on a different machine. After logging in and pressing the `Grant Access` button the page will return the authorization code that you have to copy and paste back to the `epinio` cli input to finish the authentication process.
 
 ```bash
-epinio login --oidc --prompt https://epinio.172.21.0.4.omg.howdoi.website
+epinio login --oidc --prompt https://epinio.172.21.0.4.sslip.io
 ```
 
 By default, only the local connector is setup with two users (`admin@epinio.io` and `epinio@epinio.io`).

--- a/docs/references/settings.md
+++ b/docs/references/settings.md
@@ -51,7 +51,7 @@ The `token` combines the `access_token` and `refresh_token`.
 
 If a token is present, it will be used to authenticate and takes precedence over the username and password.
 
-The installation uses the wildcard domain `omg.howdoi.website` and the
+The installation uses the wildcard domain `sslip.io` and the
 `epinio-ca` issuer by default.
 
 The `epinio login [URL]` checks if the associated certificate is signed by an

--- a/versioned_docs/version-1.11.0/howtos/other/certificate_issuers.md
+++ b/versioned_docs/version-1.11.0/howtos/other/certificate_issuers.md
@@ -146,9 +146,9 @@ Example:
     name: epinio
     namespace: epinio
   spec:
-    commonName: epinio.172.27.0.2.omg.howdoi.website
+    commonName: epinio.172.27.0.2.sslip.io
     dnsNames:
-    - epinio.172.27.0.2.omg.howdoi.website
+    - epinio.172.27.0.2.sslip.io
     issuerRef:
       kind: ClusterIssuer
       name: epinio-ca
@@ -163,9 +163,9 @@ Example:
   type: kubernetes.io/tls
   metadata:
     annotations:
-      cert-manager.io/alt-names: epinio.172.27.0.2.omg.howdoi.website
+      cert-manager.io/alt-names: epinio.172.27.0.2.sslip.io
       cert-manager.io/certificate-name: epinio
-      cert-manager.io/common-name: epinio.172.27.0.2.omg.howdoi.website
+      cert-manager.io/common-name: epinio.172.27.0.2.sslip.io
       cert-manager.io/ip-sans: ""
       cert-manager.io/issuer-group: ""
       cert-manager.io/issuer-kind: ClusterIssuer
@@ -196,7 +196,7 @@ Example:
     namespace: epinio
   spec:
     rules:
-    - host: epinio.172.27.0.2.omg.howdoi.website
+    - host: epinio.172.27.0.2.sslip.io
       http:
         paths:
         - backend:
@@ -208,7 +208,7 @@ Example:
           pathType: ImplementationSpecific
     tls:
     - hosts:
-      - epinio.172.27.0.2.omg.howdoi.website
+      - epinio.172.27.0.2.sslip.io
       secretName: epinio-tls
   ```
 

--- a/versioned_docs/version-1.11.0/howtos/other/port_forwarding.md
+++ b/versioned_docs/version-1.11.0/howtos/other/port_forwarding.md
@@ -47,7 +47,7 @@ Application: samplejava
 | StageId              | cac0d6fec92e0a1f                            |
 | Age                  | 2m50s                                       |
 | Active Routes        |                                             |
-|                      | samplejava.172.19.0.4.omg.howdoi.website    |
+|                      | samplejava.172.19.0.4.sslip.io    |
 | Desired Instances    |                                           1 |
 | Bound Configurations |                                             |
 | Environment          |                                             |

--- a/versioned_docs/version-1.11.0/howtos/use-develop/app_recover.md
+++ b/versioned_docs/version-1.11.0/howtos/use-develop/app_recover.md
@@ -66,8 +66,8 @@ spec:
   origin:
     path: /home/work/SUSE/dev/epinio/assets/sample-app
   routes:
-  - fox.172.18.0.4.omg.howdoi.website
-  - foxy.172.18.0.4.omg.howdoi.website
+  - fox.172.18.0.4.sslip.io
+  - foxy.172.18.0.4.sslip.io
   stageid: 1642fcf755ab41e8
 ```
 
@@ -154,8 +154,8 @@ The ingresses for an application `<name>` are named `r<name>-...` and the listed
 ```bash
 % kubectl get ingress -n workspace
 NAME                                                              CLASS     HOSTS                                [...]
-rfox-fox1721804omghowd-5af9c73b3c19f041d061042e158408a5275b015e   traefik   fox.172.18.0.4.omg.howdoi.website    [...]
-rfox-foxy1721804omghow-22ecdc59ff0c5c7b0f328802c6abea7739c2a388   traefik   foxy.172.18.0.4.omg.howdoi.website   [...]
+rfox-fox1721804omghowd-5af9c73b3c19f041d061042e158408a5275b015e   traefik   fox.172.18.0.4.sslip.io    [...]
+rfox-foxy1721804omghow-22ecdc59ff0c5c7b0f328802c6abea7739c2a388   traefik   foxy.172.18.0.4.sslip.io   [...]
 ```
 
 Not recoverable is the `origin` data. It is stored nowhere else in the system.

--- a/versioned_docs/version-1.11.0/installation/other_inst_scenarios/install_epinio_on_k3s.md
+++ b/versioned_docs/version-1.11.0/installation/other_inst_scenarios/install_epinio_on_k3s.md
@@ -43,7 +43,7 @@ Then, continue with the [Epinio installation process](../../installation/install
 
 If you experience issues with DNS resolution, if, for example, you have something like this in your logs:
 ```
-dial tcp: lookup epinio-registry.192.168.1.10.omg.howdoi.website on 10.43.0.10:53: no such host
+dial tcp: lookup epinio-registry.192.168.1.10.sslip.io on 10.43.0.10:53: no such host
 ```
 
 You can try to install K3s with this known-to-work DNS server:

--- a/versioned_docs/version-1.11.0/installation/other_inst_scenarios/install_epinio_on_rke.md
+++ b/versioned_docs/version-1.11.0/installation/other_inst_scenarios/install_epinio_on_rke.md
@@ -79,7 +79,7 @@ Perform the following steps on your RKE2 node before installing Epinio:
 
 ## Installation
 
-For evaluation environments we recommend that you setup Epinio Ingress resources with a wildcard DNS service such as `omg.howdoi.website`, `sslip.io`, or `nip.io` that points to the `INTERNAL-IP` address of your kubernetes node.
+For evaluation environments we recommend that you setup Epinio Ingress resources with a wildcard DNS service such as `sslip.io`, `sslip.io`, or `nip.io` that points to the `INTERNAL-IP` address of your kubernetes node.
 
 For production environments you should configure an external load-balancer solution.
 It should listen on a public IP with an associated public FQDN domain.
@@ -91,7 +91,7 @@ There are two ways of installing DNS for Epinio:
 
     For test environments.
     This should work on any kubernetes distribution.
-    Epinio will try to create a magic wildcard DNS domain, for example, **10.0.0.1.omg.howdoi.website**.
+    Epinio will try to create a magic wildcard DNS domain, for example, **10.0.0.1.sslip.io**.
 
 1. [DNS setup](../../installation/dns_setup.md)
 

--- a/versioned_docs/version-1.11.0/installation/wildcardDNS_setup.md
+++ b/versioned_docs/version-1.11.0/installation/wildcardDNS_setup.md
@@ -15,15 +15,14 @@ By "wildcard" we mean a domain that will always resolve to the IP address that i
 So, it is a record in a DNS zone that will match requests for non-existent sub-domains.
 There are a variety of free services doing this:
 
-- omg.howdoi.website
 - sslip.io
 - nip.io
 
 As examples, all the following domains resolve to `127.0.0.1`:
 
-- `127.0.0.1.omg.howdoi.website`
-- `subdomain.127.0.0.1.omg.howdoi.website`
-- `subsub.subdomain.127.0.0.1.omg.howdoi.website`
+- `127.0.0.1.sslip.io`
+- `subdomain.127.0.0.1.sslip.io`
+- `subsub.subdomain.127.0.0.1.sslip.io`
 
 You can use domains like these as a wildcard system domain for Epinio.
 
@@ -44,7 +43,7 @@ This stops a malicious website from probing the local network for hosts.
 
 This includes anything using [dnsmasq](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html) with `stop-dns-rebind`. Examples are [pfSense](https://docs.netgate.com/pfsense/en/latest/services/dns/rebinding.html) or NetworkManager.
 
-If you still want to use the default wildcard DNS, you'll have to whitelist `omg.howdoi.website`, or other providers, in your local DNS server.
+If you still want to use the default wildcard DNS, you'll have to whitelist `sslip.io`, or other providers, in your local DNS server.
 
 ### Cluster running in a VM
 

--- a/versioned_docs/version-1.11.0/references/authentication_oidc.md
+++ b/versioned_docs/version-1.11.0/references/authentication_oidc.md
@@ -16,7 +16,7 @@ epinio login --oidc https://epinio.mydomain.com
 If you are using the `epinio` cli on a machine without a browser you can provide the `--prompt` flag. This will give you the url of a web page where you can authenticate even on a different machine. After logging in and pressing the `Grant Access` button the page will return the authorization code that you have to copy and paste back to the `epinio` cli input to finish the authentication process.
 
 ```bash
-epinio login --oidc --prompt https://epinio.172.21.0.4.omg.howdoi.website
+epinio login --oidc --prompt https://epinio.172.21.0.4.sslip.io
 ```
 
 By default, only the local connector is setup with two users (`admin@epinio.io` and `epinio@epinio.io`).

--- a/versioned_docs/version-1.11.0/references/settings.md
+++ b/versioned_docs/version-1.11.0/references/settings.md
@@ -51,7 +51,7 @@ The `token` combines the `access_token` and `refresh_token`.
 
 If a token is present, it will be used to authenticate and takes precedence over the username and password.
 
-The installation uses the wildcard domain `omg.howdoi.website` and the
+The installation uses the wildcard domain `sslip.io` and the
 `epinio-ca` issuer by default.
 
 The `epinio login [URL]` checks if the associated certificate is signed by an


### PR DESCRIPTION
This removes howdoi.website as a suggested option. This is specific to the current version of the docs.