### PR TITLE
Add Homepage Link to Documentation Site Header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,12 @@ const config = {
             type: 'search',
             position: 'left',
           },
+          { 
+            href: "https://epinio.io/",
+            position: "right",
+            className: "header-home-link",
+            'aria-label': "Epinio Homepage"
+          },
           {
             href: 'https://github.com/epinio/epinio',
             position: 'right',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,6 +37,25 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.4);
 }
 
+
+.header-home-link:hover { 
+  opacity: 0.6;
+}
+
+.header-home-link::before { 
+  content: '';
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background: url("data:image/svg+xml,%3Csvg fill='black' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512'%3E%3Cpath d='M280.4 148.3L96 300.1V464c0 8.8 7.2 16 16 16l112-.3c8.8 0 16-7.2 16-16V368c0-8.8 7.2-16 16-16h64c8.8 0 16 7.2 16 16v95.7c0 8.8 7.2 16 16 16l112 .3c8.8 0 16-7.2 16-16V300L295.7 148.3c-6.5-5.3-15.9-5.3-22.4 0zM571.6 251.5L488 182.6V44c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v72.6L318.5 43.8c-20.9-17.1-51.1-17.1-72 0L4.3 251.5c-5.1 4.2-5.8 11.7-1.6 16.8l25.5 30.4c4.2 5.1 11.7 5.8 16.8 1.6L64 270.7V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V270.7l19 16.5c5.1 4.2 12.6 3.5 16.8-1.6l25.5-30.4c4.1-5.2 3.4-12.6-1.5-16.7z'/%3E%3C/svg%3E") no-repeat center center;
+}
+
+[data-theme='dark'] .header-home-link::before {
+  background: url("data:image/svg+xml,%3Csvg fill='white' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512'%3E%3Cpath d='M280.4 148.3L96 300.1V464c0 8.8 7.2 16 16 16l112-.3c8.8 0 16-7.2 16-16V368c0-8.8 7.2-16 16-16h64c8.8 0 16 7.2 16 16v95.7c0 8.8 7.2 16 16 16l112 .3c8.8 0 16-7.2 16-16V300L295.7 148.3c-6.5-5.3-15.9-5.3-22.4 0zM571.6 251.5L488 182.6V44c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v72.6L318.5 43.8c-20.9-17.1-51.1-17.1-72 0L4.3 251.5c-5.1 4.2-5.8 11.7-1.6 16.8l25.5 30.4c4.2 5.1 11.7 5.8 16.8 1.6L64 270.7V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V270.7l19 16.5c5.1 4.2 12.6 3.5 16.8-1.6l25.5-30.4c4.1-5.2 3.4-12.6-1.5-16.7z'/%3E%3C/svg%3E") no-repeat center center;
+  background-size: contain;
+}
+
+
 .header-github-link:hover {
   opacity: 0.6;
 }


### PR DESCRIPTION
Summary
This feature adds a direct link to the Epinio homepage (https://epinio.io/) in the documentation site's top navbar. This improves navigation by allowing users to return to the main site from the documentation with a single click.


closes #405 