### PR TITLE
Update completion page formatting

### DIFF
--- a/docs/references/commands/cli/epinio_completion.md
+++ b/docs/references/commands/cli/epinio_completion.md
@@ -24,10 +24,13 @@ $ source <(epinio completion bash)
 To load completions for each session, execute once:
 
 Linux:
+
 ```
 $ epinio completion bash > /etc/bash_completion.d/epinio
 ```
+
 MacOS:
+
 ```
 $ epinio completion bash > /usr/local/etc/bash_completion.d/epinio
 ```


### PR DESCRIPTION
CLI `epinio completion` page had funky and outdated formatting. This improves the formatting until the page can be fully addressed.