### PR TITLE
Backport 1.12 Changes

### DIFF
--- a/docs/howtos/operations/aws_iam_integration.md
+++ b/docs/howtos/operations/aws_iam_integration.md
@@ -85,7 +85,7 @@ aws iam delete-policy --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/EpinioE
 EKS is the Elastic Kubernetes Service.
 
 For increased security you can attach the policy to the Epinio pod ServiceAccount.
-You also need to create a specific ServiceAccount that you bind to the staging job with the `server.stagingWorkloads.serviceAccountName` value.
+You also need to create a specific ServiceAccount that you bind to the staging job with the `server.stagingServiceAccountName` value.
 
 To use AWS IAM roles for service accounts, an IAM OIDC provider must exist for your cluster's OIDC issuer URL.
 
@@ -180,14 +180,14 @@ eksctl create iamserviceaccount \
 ```
 
 You can update your Helm deployment specifying this new service account by adding the flag<br/>
-`--set server.stagingWorkloads.serviceAccountName=epinio-staging-service-account`<br/>
+`--set server.stagingServiceAccountName=epinio-staging-service-account`<br/>
 when upgrading Epinio:
 
 ```console
 helm upgrade epinio epinio/epinio \
     --namespace epinio --create-namespace \
     --set global.domain=<MY_DOMAIN> \
-    --set server.stagingWorkloads.serviceAccountName=epinio-staging-service-account \
+    --set server.stagingServiceAccountName=epinio-staging-service-account \
     --wait
 ```
 

--- a/docs/installation/install_epinio.md
+++ b/docs/installation/install_epinio.md
@@ -184,36 +184,6 @@ The Public Cloud [installation](other_inst_scenarios/install_epinio_on_public_cl
 
 ## Internal Epinio components
 
-### Staging Workloads
-
-Epinio uses staging workloads to build container images from source code.  As you can imagine, container builds can consume varying amounts of CPU, Memory, and Disk space depending on the application.  Because of this, it is important that these staging workloads can not only specify those resource amounts but also specify scheduling constraints so that your running applications can be protected from any buildtime resource consumption.  For example, you may configure your staging workloads to schedule to a particular node pool within your Kubernetes cluster that is dedicated to builds.
-
-These configurations can be set using the `server.stagingWorkloads` section of the `values.yaml` file with which you may configure the following details:
-- Resource Consumption
-    - `server.stagingWorkloads.ttlSecondsAfterFinished`
-        - Configure time-to-live for completed staging job resources
-    - `server.stagingWorkloads.resources`
-        - Provide Requests/Limits on CPU & Memory
-    - `server.stagingWorkloads.storage`
-        - `cache`
-            - Optionally toggle `emptyDir` to bypass PVC creation
-            - Provide parameters for `size`, `accessModes`, `volumeMode`, and `storageClassName`
-        - `sourceBlobs`
-            - Optionally toggle `emptyDir` to bypass PVC creation
-            - Provide parameters for `size`, `accessModes`, `volumeMode`, and `storageClassName`
-- Scheduling Constraints
-    - `server.stagingWorkloads.nodeSelector`
-        - Provide Node Selector labels to constrain scheduling to nodes that contain the specified label/value.
-    - `server.stagingWorkloads.affinity`
-        - Provide Affinity rules to constrain scheduling to nodes that meet the specified criteria.
-    - `server.stagingWorkloads.tolerations`
-        - Provide Tolerations to allow scheduling to nodes with matching taints.
-
-There exists examples within the `values.yaml` file under the `server.stagingWorkloads` key.  Please review and modify these examples to suit your environmental needs.  Review these examples at the following lines:  [Epinio Helm Chart Values:  Staging Workloads](https://github.com/epinio/helm-charts/blob/4edcf8af4d6881da4162a04e532de1298f749662/chart/epinio/values.yaml#L64-L92).
-
-The configurations under `server.stagingWorkloads` gets mapped to the build script ConfigMaps which is then processed by the Epinio Server when builds are kicked off.  These specifications are supplied to the newly created staging jobs.
-
-
 ### Kubed
 
 Kubed is installed as a subchart when `.Values.kubed.enabled` is `true` (default).
@@ -262,14 +232,3 @@ Any container registry that supports basic auth authentication (e.g. gcr, docker
 instead, by setting this value to `false` and using
 [the relevant global values](https://github.com/epinio/helm-charts/blob/b389a4875af9f03b484a911c49a14f834ba04b64/chart/epinio/values.yaml#L107-L111)
 to point to the desired container registry.
-
-
-## Upgrade
-
-### Breaking Changes & Migrations
-
-#### 1.12 to 1.13
-
-Epinio 1.13 rehomes configurations for the staging workloads to a more Kubernetes-standardized format that supports a larger variety of configs.  These are no longer configured via ENV variables on the Epinio Server or through CLI flags but rather read from an in-cluster ConfigMap at staging time.
-
-Documentation has been udpated for both the [Epinio Server](https://github.com/epinio/epinio?tab=readme-ov-file#112-to-113) and the [Epinio Helm Chart](https://github.com/epinio/helm-charts/tree/main/chart/epinio#112-to-113).  These READMEs go into detail describing the changes to the environment variables, CLI flags, and changes to the `values.yaml` interface.  Please refer to these before upgrading to **1.13**.

--- a/docs/references/commands/cli/epinio_server.md
+++ b/docs/references/commands/cli/epinio_server.md
@@ -34,6 +34,10 @@ epinio server [flags]
       --port int                              (PORT) The port to listen on. Leave empty to auto-assign a random port
       --registry-certificate-secret string    (REGISTRY_CERTIFICATE_SECRET) Secret for the registry's TLS certificate
       --s3-certificate-secret string          (S3_CERTIFICATE_SECRET) Secret for the S3 endpoint TLS certificate. Can be left empty if S3 is served with a trusted certificate.
+      --staging-resource-cpu string           (STAGING_RESOURCE_CPU)
+      --staging-resource-disk string          (STAGING_RESOURCE_DISK)
+      --staging-resource-memory string        (STAGING_RESOURCE_MEMORY)
+      --staging-service-account-name string   (STAGING_SERVICE_ACCOUNT_NAME)
       --staging-resource-cpu string           (STAGING_RESOURCE_CPU) NOTICE: Removed in 1.13 in favor of enhanced configurability options via Helm.
       --staging-resource-disk string          (STAGING_RESOURCE_DISK) NOTICE: Removed in 1.13 in favor of enhanced configurability options via Helm.
       --staging-resource-memory string        (STAGING_RESOURCE_MEMORY) NOTICE: Removed in 1.13 in favor of enhanced configurability options via Helm.


### PR DESCRIPTION
Due to issues with docusaurus not tagging proper versions, we need to back port some changes for 1.12,  